### PR TITLE
Dev 9420- CEDCD: 508 improvements

### DIFF
--- a/.github/workflows/update-db.yml
+++ b/.github/workflows/update-db.yml
@@ -31,7 +31,7 @@ jobs:
       APP: cedcd
       AWS_REGION: us-east-1
       TIER: ${{ inputs.tier }}
-      CICD_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
+      CICD_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
 
     steps:
       - name: Configure AWS credentials

--- a/client/src/components/Admin/AddNewCohort.js
+++ b/client/src/components/Admin/AddNewCohort.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
 import AccessibleSelect from "../controls/AccessibleSelect";
 import { connect } from "react-redux";
-import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
 import Messenger from "../Snackbar/Snackbar";
 import "./AddNewCohort.css";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/Admin/AddNewCohort.js
+++ b/client/src/components/Admin/AddNewCohort.js
@@ -399,7 +399,7 @@ class AddNewCohort extends Component {
                       <AccessibleSelect
                         inputId="cu_organization"
                         name="owners"
-                        isMulti="true"
+                        isMulti
                         value={this.state.cohortOwners}
                         options={this.state.ownerOptions}
                         onChange={this.handleMultiChange}

--- a/client/src/components/Admin/AddNewCohort.js
+++ b/client/src/components/Admin/AddNewCohort.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
-import Select from "react-select";
+import AccessibleSelect from "../controls/AccessibleSelect";
 import { connect } from "react-redux";
 import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
 import Messenger from "../Snackbar/Snackbar";
@@ -339,10 +339,10 @@ class AddNewCohort extends Component {
                   <p id="ctl11_rg_errorMsg" className="bg-danger"></p>
                   <Form.Group id="ctl11_div_cohortName">
                     <Form.Label className="oneLineLabel" htmlFor="cu_firstName">
-                      Cohort Name<span style={{ color: "red" }}>*</span>
+                      Cohort Name<span className="error-text">*</span>
                     </Form.Label>
                     {this.state.name_error !== "" && (
-                      <Form.Label style={{ color: "red" }}> {this.state.name_error}</Form.Label>
+                      <Form.Label className="error-text"> {this.state.name_error}</Form.Label>
                     )}
                     <input
                       className="form-control"
@@ -356,10 +356,10 @@ class AddNewCohort extends Component {
                   </Form.Group>
                   <Form.Group id="ctl11_div_cohortAcronym">
                     <Form.Label className="oneLineLabel" htmlFor="cu_lastName">
-                      Cohort Acronym<span style={{ color: "red" }}>*</span>
+                      Cohort Acronym<span className="error-text">*</span>
                     </Form.Label>
                     {this.state.acronym_error !== "" && (
-                      <Form.Label style={{ color: "red" }}> {this.state.acronym_error}</Form.Label>
+                      <Form.Label className="error-text"> {this.state.acronym_error}</Form.Label>
                     )}
                     <input
                       className="form-control"
@@ -373,13 +373,14 @@ class AddNewCohort extends Component {
                   </Form.Group>
                   <Form.Group id="ctl11_div_cohortType">
                     <Form.Label className="oneLineLabel" htmlFor="cu_type">
-                      Cohort Type<span style={{ color: "red" }}>*</span>
+                      Cohort Type<span className="error-text">*</span>
                     </Form.Label>
                     {this.state.type_error !== "" && (
-                      <Form.Label style={{ color: "red" }}> {this.state.type_error}</Form.Label>
+                      <Form.Label className="error-text"> {this.state.type_error}</Form.Label>
                     )}
                     <div style={{ width: "90%" }}>
-                      <Select
+                      <AccessibleSelect
+                        inputId="cu_type"
                         name="type"
                         value={this.state.type}
                         options={[
@@ -395,7 +396,8 @@ class AddNewCohort extends Component {
                       Cohort Owner(s)
                     </Form.Label>
                     <div style={{ width: "90%" }}>
-                      <Select
+                      <AccessibleSelect
+                        inputId="cu_organization"
                         name="owners"
                         isMulti="true"
                         value={this.state.cohortOwners}
@@ -409,7 +411,7 @@ class AddNewCohort extends Component {
                       Notes{" "}
                     </Form.Label>
                     {this.state.notes_error !== "" && (
-                      <Form.Label style={{ color: "red", paddingLeft: "5px" }}> {this.state.notes_error}</Form.Label>
+                      <Form.Label className="error-text" style={{ paddingLeft: "5px" }}> {this.state.notes_error}</Form.Label>
                     )}
                     <textarea
                       className="form-control"

--- a/client/src/components/Admin/AddNewCohort.js
+++ b/client/src/components/Admin/AddNewCohort.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
-import AccessibleSelect from "../controls/AccessibleSelect";
+import Select from "../controls/Select";
 import { connect } from "react-redux";
 import Messenger from "../Snackbar/Snackbar";
 import "./AddNewCohort.css";
@@ -378,7 +378,7 @@ class AddNewCohort extends Component {
                       <Form.Label className="error-text"> {this.state.type_error}</Form.Label>
                     )}
                     <div style={{ width: "90%" }}>
-                      <AccessibleSelect
+                      <Select
                         inputId="cu_type"
                         name="type"
                         value={this.state.type}
@@ -395,7 +395,7 @@ class AddNewCohort extends Component {
                       Cohort Owner(s)
                     </Form.Label>
                     <div style={{ width: "90%" }}>
-                      <AccessibleSelect
+                      <Select
                         inputId="cu_organization"
                         name="owners"
                         isMulti

--- a/client/src/components/Admin/CohortActivity.js
+++ b/client/src/components/Admin/CohortActivity.js
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useParams, NavLink } from "react-router-dom";
 import Table from "react-bootstrap/Table";
-import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
-import PageSummary from "../Paging/Paging";
 import Paging from "../Paging/Paging";
 import AccessiblePageSizeSelect from "../controls/AccessiblePageSizeSelect";
 

--- a/client/src/components/Admin/CohortActivity.js
+++ b/client/src/components/Admin/CohortActivity.js
@@ -4,6 +4,7 @@ import Table from "react-bootstrap/Table";
 import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
 import PageSummary from "../Paging/Paging";
 import Paging from "../Paging/Paging";
+import AccessiblePageSizeSelect from "../controls/AccessiblePageSizeSelect";
 
 export default function CohortActivity() {
   const { abbreviation } = useParams();
@@ -102,20 +103,20 @@ export default function CohortActivity() {
 
         <div className="d-flex align-items-center justify-content-between">
           <div>
-            <label htmlFor="page-size" className="mr-1">
-              Page Size:{" "}
-            </label>
-            <select
-              id="page-size"
+            <AccessiblePageSizeSelect
+              id="cohort-activity-page-size"
               value={pageSize}
               onChange={(e) => {
-                setPageSize(e.target.value);
+                setPageSize(Number(e.target.value));
                 setPage(0);
-              }}>
-              {[5, 10, 15, 20].map((size) => (
-                <option value={size}>{size}</option>
-              ))}
-            </select>
+              }}
+              options={[
+                { value: 5, label: "5" },
+                { value: 10, label: "10" },
+                { value: 15, label: "15" },
+                { value: 20, label: "20" },
+              ]}
+            />
           </div>
 
           <div className="d-flex">

--- a/client/src/components/Admin/CohortActivity.js
+++ b/client/src/components/Admin/CohortActivity.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useParams, NavLink } from "react-router-dom";
 import Table from "react-bootstrap/Table";
 import Paging from "../Paging/Paging";
-import AccessiblePageSizeSelect from "../controls/AccessiblePageSizeSelect";
+import PageSizeSelect from "../controls/PageSizeSelect";
 
 export default function CohortActivity() {
   const { abbreviation } = useParams();
@@ -101,7 +101,7 @@ export default function CohortActivity() {
 
         <div className="d-flex align-items-center justify-content-between">
           <div>
-            <AccessiblePageSizeSelect
+            <PageSizeSelect
               id="cohort-activity-page-size"
               value={pageSize}
               onChange={(e) => {

--- a/client/src/components/Admin/EditUser.js
+++ b/client/src/components/Admin/EditUser.js
@@ -343,6 +343,7 @@ const EditUser = ({ ...props }) => {
                       <Form.Check.Input
                         id="login_type_logingov"
                         type="radio"
+                        name="login_type"
                         value="Login.gov"
                         checked={loginType === "Login.gov"}
                         onChange={(e) => {
@@ -360,6 +361,7 @@ const EditUser = ({ ...props }) => {
                       <Form.Check.Input
                         id="login_type_nih"
                         type="radio"
+                        name="login_type"
                         value="NIH"
                         checked={loginType === "NIH"}
                         onChange={(e) => {
@@ -463,6 +465,7 @@ const EditUser = ({ ...props }) => {
                       <Form.Check.Input
                         id="user_role_owner"
                         type="radio"
+                        name="user_role"
                         value="Cohort Owner"
                         checked={userRole === "Cohort Owner"}
                         onChange={(e) => {
@@ -475,6 +478,7 @@ const EditUser = ({ ...props }) => {
                       <Form.Check.Input
                         id="user_role_admin"
                         type="radio"
+                        name="user_role"
                         value="Admin"
                         checked={userRole === "Admin"}
                         onChange={(e) => {
@@ -537,21 +541,6 @@ const EditUser = ({ ...props }) => {
                 </div>
               </Form>
 
-              {/* <div className="bttn-group col-md-12 col-xs-12">
-                                <Button 
-                                    variant="primary"
-                                    value="Save" 
-                                    className="col-lg-2 col-md-6 float-right"
-                                    onClick={handleSave}>
-                                    Save
-                                </Button>
-                                <Button 
-                                    variant="secondary" 
-                                    className="col-lg-2 col-md-6 float-right" 
-                                    onClick={goBack}>
-                                    Cancel
-                                </Button>
-                            </div> */}
             </div>
           )}
         </div>

--- a/client/src/components/Admin/EditUser.js
+++ b/client/src/components/Admin/EditUser.js
@@ -338,43 +338,42 @@ const EditUser = ({ ...props }) => {
                   <Col sm="6" className="d-flex justify-content-between align-self-center">
                     <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
                       <legend>Login Type <span className="error-text">*</span></legend>
-                      <Form.Check.Input
-                        id="login_type_logingov"
-                        type="radio"
-                        name="login_type"
-                        value="Login.gov"
-                        checked={loginType === "Login.gov"}
-                        onChange={(e) => {
-                          setLoginType(e.target.value);
-                          if (errors.loginType_error !== "") {
-                            if (LOGIN_EMAIL_ERR_MSG.valueOf() === errors.loginType_error) {
-                              setErrors({ ...errors, email_error: "", loginType_error: "" });
-                            } else {
-                              setErrors({ ...errors, loginType_error: "" });
+                      <Form.Check type="radio" id="login_type_logingov" inline name="login_type">
+                        <Form.Check.Input
+                          type="radio"
+                          value="Login.gov"
+                          checked={loginType === "Login.gov"}
+                          onChange={(e) => {
+                            setLoginType(e.target.value);
+                            if (errors.loginType_error !== "") {
+                              if (LOGIN_EMAIL_ERR_MSG.valueOf() === errors.loginType_error) {
+                                setErrors({ ...errors, email_error: "", loginType_error: "" });
+                              } else {
+                                setErrors({ ...errors, loginType_error: "" });
+                              }
                             }
-                          }
-                        }}
-                      />
-                      <Form.Check.Label htmlFor="login_type_logingov" style={{ fontWeight: "normal" }}>Login.gov</Form.Check.Label>
-                      <Form.Check.Input
-                        id="login_type_nih"
-                        type="radio"
-                        name="login_type"
-                        value="NIH"
-                        checked={loginType === "NIH"}
-                        onChange={(e) => {
-                          setLoginType(e.target.value);
-
-                          if (errors.loginType_error !== "") {
-                            if (LOGIN_EMAIL_ERR_MSG.valueOf() === errors.loginType_error) {
-                              setErrors({ ...errors, email_error: "", loginType_error: "" });
-                            } else {
-                              setErrors({ ...errors, loginType_error: "" });
+                          }}
+                        />
+                        <Form.Check.Label htmlFor="login_type_logingov" style={{ fontWeight: "normal" }}>Login.gov</Form.Check.Label>
+                      </Form.Check>
+                      <Form.Check type="radio" id="login_type_nih" inline name="login_type">
+                        <Form.Check.Input
+                          type="radio"
+                          value="NIH"
+                          checked={loginType === "NIH"}
+                          onChange={(e) => {
+                            setLoginType(e.target.value);
+                            if (errors.loginType_error !== "") {
+                              if (LOGIN_EMAIL_ERR_MSG.valueOf() === errors.loginType_error) {
+                                setErrors({ ...errors, email_error: "", loginType_error: "" });
+                              } else {
+                                setErrors({ ...errors, loginType_error: "" });
+                              }
                             }
-                          }
-                        }}
-                      />
-                      <Form.Check.Label htmlFor="login_type_nih" style={{ fontWeight: "normal" }}>NIH &nbsp; &nbsp;</Form.Check.Label>
+                          }}
+                        />
+                        <Form.Check.Label htmlFor="login_type_nih" style={{ fontWeight: "normal" }}>NIH &nbsp; &nbsp;</Form.Check.Label>
+                      </Form.Check>
                     </fieldset>
                   </Col>
                 </Form.Group>
@@ -460,31 +459,31 @@ const EditUser = ({ ...props }) => {
                   <Col sm="6" className="d-flex justify-content-between align-self-center">
                     <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
                       <legend>User Role <span className="error-text">*</span></legend>
-                      <Form.Check.Input
-                        id="user_role_owner"
-                        type="radio"
-                        name="user_role"
-                        value="Cohort Owner"
-                        checked={userRole === "Cohort Owner"}
-                        onChange={(e) => {
-                          setUserRole(e.target.value);
-                          setCohortList([]);
-                          if (errors.userRole_error !== "") setErrors({ ...errors, userRole_error: "" });
-                        }}
-                      />
-                      <Form.Check.Label htmlFor="user_role_owner" style={{ fontWeight: "normal" }}>Cohort Owner</Form.Check.Label>
-                      <Form.Check.Input
-                        id="user_role_admin"
-                        type="radio"
-                        name="user_role"
-                        value="Admin"
-                        checked={userRole === "Admin"}
-                        onChange={(e) => {
-                          setUserRole(e.target.value);
-                          if (errors.userRole_error !== "") setErrors({ ...errors, userRole_error: "" });
-                        }}
-                      />
-                      <Form.Check.Label htmlFor="user_role_admin" style={{ fontWeight: "normal" }}>Admin</Form.Check.Label>
+                      <Form.Check type="radio" id="user_role_owner" inline name="user_role">
+                        <Form.Check.Input
+                          type="radio"
+                          value="Cohort Owner"
+                          checked={userRole === "Cohort Owner"}
+                          onChange={(e) => {
+                            setUserRole(e.target.value);
+                            setCohortList([]);
+                            if (errors.userRole_error !== "") setErrors({ ...errors, userRole_error: "" });
+                          }}
+                        />
+                        <Form.Check.Label htmlFor="user_role_owner" style={{ fontWeight: "normal" }}>Cohort Owner</Form.Check.Label>
+                      </Form.Check>
+                      <Form.Check type="radio" id="user_role_admin" inline name="user_role">
+                        <Form.Check.Input
+                          type="radio"
+                          value="Admin"
+                          checked={userRole === "Admin"}
+                          onChange={(e) => {
+                            setUserRole(e.target.value);
+                            if (errors.userRole_error !== "") setErrors({ ...errors, userRole_error: "" });
+                          }}
+                        />
+                        <Form.Check.Label htmlFor="user_role_admin" style={{ fontWeight: "normal" }}>Admin</Form.Check.Label>
+                      </Form.Check>
                     </fieldset>
                   </Col>
                 </Form.Group>

--- a/client/src/components/Admin/EditUser.js
+++ b/client/src/components/Admin/EditUser.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useHistory, NavLink } from "react-router-dom";
-import Select from "react-select";
+import AccessibleSelect from '../controls/AccessibleSelect';
 import validator from "../../validators";
 import Messenger from "../Snackbar/Snackbar";
 import CenterModal from "../controls/modal/modal";
@@ -343,15 +343,14 @@ const EditUser = ({ ...props }) => {
                                 </Form.Group> */}
 
                 <Form.Group id="ctl11_div_loginType" className="pl-0 my-3 col-md-12 col-12">
-                  <Form.Label className="col-md-12 col-12" htmlFor="login_type" style={{ paddingLeft: "0" }}>
-                    Login Type<span style={{ color: "red" }}>*</span>
-                  </Form.Label>
                   {errors.loginType_error !== "" && (
-                    <Form.Label style={{ color: "red" }}>{errors.loginType_error}</Form.Label>
+                    <Form.Label className="error-text">{errors.loginType_error}</Form.Label>
                   )}
                   <Col sm="6" className="d-flex justify-content-between align-self-center">
-                    <Form.Check type="radio" inline>
+                    <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                      <legend>Login Type <span className="error-text">*</span></legend>
                       <Form.Check.Input
+                        id="login_type_logingov"
                         type="radio"
                         value="Login.gov"
                         checked={loginType === "Login.gov"}
@@ -366,11 +365,9 @@ const EditUser = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Login.gov</Form.Check.Label>
-                    </Form.Check>
-
-                    <Form.Check type="radio" inline>
+                      <Form.Check.Label htmlFor="login_type_logingov" style={{ fontWeight: "normal" }}>Login.gov</Form.Check.Label>
                       <Form.Check.Input
+                        id="login_type_nih"
                         type="radio"
                         value="NIH"
                         checked={loginType === "NIH"}
@@ -386,16 +383,16 @@ const EditUser = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>NIH &nbsp; &nbsp;</Form.Check.Label>
-                    </Form.Check>
+                      <Form.Check.Label htmlFor="login_type_nih" style={{ fontWeight: "normal" }}>NIH &nbsp; &nbsp;</Form.Check.Label>
+                    </fieldset>
                   </Col>
                 </Form.Group>
 
                 <Form.Group id="ctl11_div_userEmail" className="px-0 my-3 col-md-12 col-12">
                   <Form.Label className="col-md-12 col-12" htmlFor="user_email" style={{ paddingLeft: "0" }}>
-                    Account Email<span style={{ color: "red" }}>*</span>
+                    Account Email<span className="error-text">*</span>
                   </Form.Label>
-                  {errors.email_error !== "" && <Form.Label style={{ color: "red" }}>{errors.email_error}</Form.Label>}
+                  {errors.email_error !== "" && <Form.Label className="error-text">{errors.email_error}</Form.Label>}
                   <span className="col-md-12 col-12" style={{ paddingLeft: "0" }}>
                     <input
                       className="form-control"
@@ -421,10 +418,10 @@ const EditUser = ({ ...props }) => {
 
                 <Form.Group id="ctl11_div_lastName" className="px-0 my-3 col-md-12 col-12">
                   <Form.Label className="col-md-12 col-12" htmlFor="user_lastName" style={{ paddingLeft: "0" }}>
-                    Last Name<span style={{ color: "red" }}>*</span>
+                    Last Name<span className="error-text">*</span>
                   </Form.Label>
                   {errors.lastName_error !== "" && (
-                    <Form.Label style={{ color: "red" }}>{errors.lastName_error}</Form.Label>
+                    <Form.Label className="error-text">{errors.lastName_error}</Form.Label>
                   )}
                   <span className="col-md-12 col-12" style={{ paddingLeft: "0" }}>
                     <input
@@ -444,10 +441,10 @@ const EditUser = ({ ...props }) => {
                 </Form.Group>
                 <Form.Group id="ctl11_div_firstName" className="px-0 my-3 col-md-12 col-12">
                   <Form.Label className="col-md-12 col-12" htmlFor="user_firstName" style={{ paddingLeft: "0" }}>
-                    First Name<span style={{ color: "red" }}>*</span>
+                    First Name<span className="error-text">*</span>
                   </Form.Label>
                   {errors.firstName_error !== "" && (
-                    <Form.Label style={{ color: "red" }}>{errors.firstName_error}</Form.Label>
+                    <Form.Label className="error-text">{errors.firstName_error}</Form.Label>
                   )}
                   <span className="col-md-12 col-12" style={{ paddingLeft: "0" }}>
                     <input
@@ -466,15 +463,14 @@ const EditUser = ({ ...props }) => {
                   </span>
                 </Form.Group>
                 <Form.Group id="ctl11_div_userRole" className="pl-0 my-3 col-md-12 col-12">
-                  <Form.Label className="col-md-12 col-12" htmlFor="user_role" style={{ paddingLeft: "0" }}>
-                    Role<span style={{ color: "red" }}>*</span>
-                  </Form.Label>
                   {errors.userRole_error !== "" && (
-                    <Form.Label style={{ color: "red" }}>{errors.userRole_error}</Form.Label>
+                    <Form.Label className="error-text">{errors.userRole_error}</Form.Label>
                   )}
                   <Col sm="6" className="d-flex justify-content-between align-self-center">
-                    <Form.Check type="radio" inline>
+                    <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                      <legend>User Role <span className="error-text">*</span></legend>
                       <Form.Check.Input
+                        id="user_role_owner"
                         type="radio"
                         value="Cohort Owner"
                         checked={userRole === "Cohort Owner"}
@@ -484,11 +480,9 @@ const EditUser = ({ ...props }) => {
                           if (errors.userRole_error !== "") setErrors({ ...errors, userRole_error: "" });
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Cohort Owner</Form.Check.Label>
-                    </Form.Check>
-
-                    <Form.Check type="radio" inline>
+                      <Form.Check.Label htmlFor="user_role_owner" style={{ fontWeight: "normal" }}>Cohort Owner</Form.Check.Label>
                       <Form.Check.Input
+                        id="user_role_admin"
                         type="radio"
                         value="Admin"
                         checked={userRole === "Admin"}
@@ -497,13 +491,13 @@ const EditUser = ({ ...props }) => {
                           if (errors.userRole_error !== "") setErrors({ ...errors, userRole_error: "" });
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Admin</Form.Check.Label>
-                    </Form.Check>
+                      <Form.Check.Label htmlFor="user_role_admin" style={{ fontWeight: "normal" }}>Admin</Form.Check.Label>
+                    </fieldset>
                   </Col>
                 </Form.Group>
 
                 <Form.Group className="pl-0 my-3 col-md-12 col-12" style={{ paddingLeft: "0" }}>
-                  <Form.Label className="pl-0 col-md-12 col-12">Cohort</Form.Label>
+                  <Form.Label className="pl-0 col-md-12 col-12" htmlFor="cohort_select">Cohort</Form.Label>
 
                   {userRole === "Admin" ? (
                     <div className="px-0 col-md-12 col-12">
@@ -514,9 +508,10 @@ const EditUser = ({ ...props }) => {
                   ) : (
                     <div className="col-md-12 col-12 px-0">
                       <div className="col-md-12 col-12 px-0">
-                        <Select
+                        <AccessibleSelect
+                          inputId="cohort_select"
                           name="owners"
-                          isMulti="true"
+                          isMulti
                           value={cohortList}
                           options={allCohortList}
                           onChange={handleMultiChange}
@@ -529,6 +524,7 @@ const EditUser = ({ ...props }) => {
                   <div className="pl-0 col-md-12 col-12">
                     <span className="col-md-12 col-12" style={{ paddingLeft: "0", paddingRight: "10" }}>
                       <input
+                        id="active_status_checkbox"
                         type="checkbox"
                         name="active_status"
                         checked={activeStatus ? activeStatus === "Y" : true}
@@ -536,7 +532,7 @@ const EditUser = ({ ...props }) => {
                           activeStatus === "Y" ? setActiveStatus("N") : setActiveStatus("Y");
                         }}
                       />{" "}
-                      Active
+                      <label htmlFor="active_status_checkbox">Active</label>
                     </span>
                   </div>
                 </Form.Group>

--- a/client/src/components/Admin/EditUser.js
+++ b/client/src/components/Admin/EditUser.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useHistory, NavLink } from "react-router-dom";
-import AccessibleSelect from "../controls/AccessibleSelect";
+import Select from "../controls/Select";
 import validator from "../../validators";
 import Messenger from "../Snackbar/Snackbar";
 import CenterModal from "../controls/modal/modal";
@@ -500,7 +500,7 @@ const EditUser = ({ ...props }) => {
                   ) : (
                     <div className="col-md-12 col-12 px-0">
                       <div className="col-md-12 col-12 px-0">
-                        <AccessibleSelect
+                        <Select
                           inputId="cohort_select"
                           name="owners"
                           isMulti

--- a/client/src/components/Admin/EditUser.js
+++ b/client/src/components/Admin/EditUser.js
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { useHistory, NavLink } from "react-router-dom";
-import AccessibleSelect from '../controls/AccessibleSelect';
+import AccessibleSelect from "../controls/AccessibleSelect";
 import validator from "../../validators";
 import Messenger from "../Snackbar/Snackbar";
 import CenterModal from "../controls/modal/modal";
-import Unauthorized from "../Unauthorized/Unauthorized";
-import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
 import "./AddNewCohort.css";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";

--- a/client/src/components/Admin/EditUser.js
+++ b/client/src/components/Admin/EditUser.js
@@ -332,15 +332,6 @@ const EditUser = ({ ...props }) => {
             <div id="edituser-col-1" className="col-md-6 col-6">
               <Form>
                 <p id="ctl11_rg_errorMsg" className="bg-danger"></p>
-                {/* <Form.Group id="ctl11_div_userName" className="px-0 my-3 col-md-12 col-12">
-                                    <Form.Label className="col-md-12 col-12" htmlFor="user_name" style={{ paddingLeft: '0' }}>User Account Name<span style={{ color: 'red' }}>*</span></Form.Label>
-                                    {errors.userName_error !== '' && <Form.Label style={{ color: 'red' }}>{errors.userName_error}</Form.Label>}
-                                    <span className="col-md-12 col-12" style={{ paddingLeft: '0' }}>
-                                        <input className="form-control" name="user_userName" type="text" placeholder='Max of 100 characters'
-                                            id="user_userName" value={userName} maxLength="100"
-                                            onChange={(e) => { setUserName(e.target.value); if (errors.userName_error !== '') setErrors({ ...errors, userName_error: '' }) }} />
-                                    </span>
-                                </Form.Group> */}
 
                 <Form.Group id="ctl11_div_loginType" className="pl-0 my-3 col-md-12 col-12">
                   {errors.loginType_error !== "" && (

--- a/client/src/components/Admin/ManageCohort.js
+++ b/client/src/components/Admin/ManageCohort.js
@@ -5,7 +5,7 @@ import PageSummary from "../PageSummary/PageSummary";
 import Paging from "../Paging/Paging";
 import CohortStatusList from "./CohortStatusList";
 import TableHeaderManageCohort from "./TableHeaderManageCohort";
-import AccessiblePageSizeSelect from "../controls/AccessiblePageSizeSelect";
+import PageSizeSelect from "../controls/PageSizeSelect";
 import { isNull } from "lodash";
 
 import "./ManageCohort.css";
@@ -432,7 +432,7 @@ class ManageCohort extends Component {
               ""
             ) : (
               <div className="pageSize" style={{ verticalAlign: "middle", paddingTop: "2px" }}>
-                <AccessiblePageSizeSelect
+                <PageSizeSelect
                   id="manage-cohort-page-size"
                   value={this.state.pageInfo.pageSize}
                   onChange={(e) => this.handleCohortPageSizeChange(e)}

--- a/client/src/components/Admin/ManageCohort.js
+++ b/client/src/components/Admin/ManageCohort.js
@@ -5,6 +5,7 @@ import PageSummary from "../PageSummary/PageSummary";
 import Paging from "../Paging/Paging";
 import CohortStatusList from "./CohortStatusList";
 import TableHeaderManageCohort from "./TableHeaderManageCohort";
+import AccessiblePageSizeSelect from "../controls/AccessiblePageSizeSelect";
 import { isNull } from "lodash";
 
 import "./ManageCohort.css";
@@ -431,16 +432,17 @@ class ManageCohort extends Component {
               ""
             ) : (
               <div className="pageSize" style={{ verticalAlign: "middle", paddingTop: "2px" }}>
-                Page Size:{" "}
-                <select
-                  className="pageSizeSelect"
+                <AccessiblePageSizeSelect
+                  id="manage-cohort-page-size"
                   value={this.state.pageInfo.pageSize}
-                  onChange={(e) => this.handleCohortPageSizeChange(e)}>
-                  <option value="5">5</option>
-                  <option value="10">10</option>
-                  <option value="15">15</option>
-                  <option value="20">20</option>
-                </select>
+                  onChange={(e) => this.handleCohortPageSizeChange(e)}
+                  options={[
+                    { value: 5, label: "5" },
+                    { value: 10, label: "10" },
+                    { value: 15, label: "15" },
+                    { value: 20, label: "20" },
+                  ]}
+                />
               </div>
             )}
             <div style={{ marginLeft: "auto", paddingRight: "1rem", paddingTop: "4px" }}>

--- a/client/src/components/Admin/ManageUser.js
+++ b/client/src/components/Admin/ManageUser.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import PageSummary from "../PageSummary/PageSummary";
 import Paging from "../Paging/Paging";
 import TableHeaderManageUser from "./TableHeaderManageUser";
-import AccessiblePageSizeSelect from "../controls/AccessiblePageSizeSelect";
+import PageSizeSelect from "../controls/PageSizeSelect";
 import "./ManageCohort.css";
 import { isNull } from "lodash";
 
@@ -351,7 +351,7 @@ class ManageUser extends Component {
               ""
             ) : (
               <div className="pageSize" style={{ verticalAlign: "middle", paddingTop: "2px" }}>
-                <AccessiblePageSizeSelect
+                <PageSizeSelect
                   id="manage-user-page-size"
                   value={this.state.pageInfo.pageSize}
                   onChange={(e) => this.handleUserPageSizeChange(e)}

--- a/client/src/components/Admin/ManageUser.js
+++ b/client/src/components/Admin/ManageUser.js
@@ -129,7 +129,7 @@ class ManageUser extends Component {
   }
 
   handleUserPageSizeChange = (e) => {
-    this.refreshDataList(1, null, null, e.target.value, null);
+    this.refreshDataList(1, null, null, Number(e.target.value), null);
   };
 
   componentDidMount() {

--- a/client/src/components/Admin/ManageUser.js
+++ b/client/src/components/Admin/ManageUser.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import PageSummary from "../PageSummary/PageSummary";
 import Paging from "../Paging/Paging";
 import TableHeaderManageUser from "./TableHeaderManageUser";
+import AccessiblePageSizeSelect from "../controls/AccessiblePageSizeSelect";
 import "./ManageCohort.css";
 import { isNull } from "lodash";
 
@@ -350,16 +351,17 @@ class ManageUser extends Component {
               ""
             ) : (
               <div className="pageSize" style={{ verticalAlign: "middle", paddingTop: "2px" }}>
-                Page Size:{" "}
-                <select
-                  className="pageSizeSelect"
+                <AccessiblePageSizeSelect
+                  id="manage-user-page-size"
                   value={this.state.pageInfo.pageSize}
-                  onChange={(e) => this.handleUserPageSizeChange(e)}>
-                  <option value="5">5</option>
-                  <option value="10">10</option>
-                  <option value="15">15</option>
-                  <option value="20">20</option>
-                </select>
+                  onChange={(e) => this.handleUserPageSizeChange(e)}
+                  options={[
+                    { value: 5, label: "5" },
+                    { value: 10, label: "10" },
+                    { value: 15, label: "15" },
+                    { value: 20, label: "20" },
+                  ]}
+                />
               </div>
             )}
             <div style={{ marginLeft: "auto", paddingRight: "1rem", paddingTop: "4px" }}>

--- a/client/src/components/Admin/TableHeaderManageCohort.js
+++ b/client/src/components/Admin/TableHeaderManageCohort.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import { Link } from "react-router-dom";
 import "./TableHeaderManageCohort.css";
 
 class TableHeaderManageCohort extends Component {

--- a/client/src/components/Admin/TableHeaderManageUser.js
+++ b/client/src/components/Admin/TableHeaderManageUser.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import { Link } from "react-router-dom";
 import "./TableHeaderManageCohort.css";
 
 class TableHeaderManageUser extends Component {

--- a/client/src/components/Cancer/Cancer.css
+++ b/client/src/components/Cancer/Cancer.css
@@ -1,6 +1,6 @@
 .cancerTableTitle {
   text-align: center;
-  color: #01857b;
+  color: #006a62;
   opacity: 1;
   font-size: 1.75rem !important;
 }

--- a/client/src/components/CancerInfoForm/CancerInfoForm.css
+++ b/client/src/components/CancerInfoForm/CancerInfoForm.css
@@ -35,7 +35,7 @@
 .btn-cancer-form.active,
 .open > .dropdown-toggle.btn-cancer-form {
   color: #fff !important;
-  background-color: lightseagreen !important;
+  background-color: #007068 !important;
   border-color: #01857b !important;
 }
 

--- a/client/src/components/CancerInfoForm/CancerInfoForm.js
+++ b/client/src/components/CancerInfoForm/CancerInfoForm.js
@@ -574,10 +574,10 @@ const CancerInfoForm = ({ ...props }) => {
                 </ButtonGroup>
               </div>
               <div className="table-responsive mb-4">
-                <Table bordered condensed className="table-valign-middle">
+                <Table bordered condensed className="table-valign-middle" aria-label="Cancer cases by racial category, ethnicity, and sex">
                   <thead>
                     <tr>
-                      <th rowSpan="3" style={{ fontSize: "1.5rem", paddingRight: "0", width: "15%" }}>
+                      <th scope="col" rowSpan="3" style={{ fontSize: "1.5rem", paddingRight: "0", width: "15%" }}>
                         Racial Categories
                       </th>
                       {lookup.cancer
@@ -585,7 +585,7 @@ const CancerInfoForm = ({ ...props }) => {
                         .map((i) => {
                           if (i.id === parseInt(`${cancerSelected}`)) {
                             return (
-                              <th colSpan="6" className="cancer-table-head " key={i.id}>
+                              <th scope="colgroup" colSpan="6" className="cancer-table-head " key={i.id}>
                                 {" "}
                                 <b>
                                   {" "}
@@ -595,7 +595,7 @@ const CancerInfoForm = ({ ...props }) => {
                             );
                           }
                         })}
-                      <th rowSpan="3" style={{ width: "10%", textAlign: "center" }}>
+                      <th scope="col" rowSpan="3" style={{ width: "10%", textAlign: "center" }}>
                         Total
                       </th>
                     </tr>
@@ -603,7 +603,7 @@ const CancerInfoForm = ({ ...props }) => {
                       {inputTypes.map(({ ethnicityType }, i) => {
                         if (i % 2 === 0)
                           return (
-                            <th colSpan="2" className="text-center" key={i}>
+                            <th scope="colgroup" colSpan="2" className="text-center" key={i}>
                               {lookupMap[ethnicityType].ethnicity}
                             </th>
                           );
@@ -612,7 +612,7 @@ const CancerInfoForm = ({ ...props }) => {
                     <tr>
                       {inputTypes.map(({ sex }, i) => {
                         return (
-                          <th className="text-center" key={i}>
+                          <th scope="col" className="text-center" key={i}>
                             {lookupMap[sex].gender}s
                           </th>
                         );
@@ -634,8 +634,8 @@ const CancerInfoForm = ({ ...props }) => {
                             <td key={key} className={classNames("p-0", submitted && errors[key] && "has-error")}>
                               <Form.Control
                                 className="input-number"
-                                title={`Cancer Site/Type: ${c.cancer} - ${inputTypes[i].ethnicityType} ${inputTypes[i].sex} cases `}
-                                aria-label={`Cancer Site/Type: ${c.cancer} - ${inputTypes[i].ethnicityType} ${inputTypes[i].sex} cases `}
+                                title={`${c.race} - ${lookupMap[inputTypes[i].ethnicityType].ethnicity} - ${lookupMap[inputTypes[i].sex].gender}s`}
+                                aria-label={`${c.race} - ${lookupMap[inputTypes[i].ethnicityType].ethnicity} - ${lookupMap[inputTypes[i].sex].gender}s`}
                                 type="number"
                                 min="0"
                                 name={key}

--- a/client/src/components/CohortForm/CohortForm.js
+++ b/client/src/components/CohortForm/CohortForm.js
@@ -944,7 +944,7 @@ const CohortForm = ({ ...props }) => {
                   <Reminder message={errors.cohort_web_site}>
                     <Form.Control
                       type="text"
-                      style={{ color: "red", border: "1px solid red" }}
+                      style={{ color: "#b91c1c", border: "1px solid #b91c1c" }}
                       placeholder="Max of 200 characters"
                       maxLength="200"
                       value={cohort.cohort_web_site}
@@ -997,14 +997,15 @@ const CohortForm = ({ ...props }) => {
                 <span className="required-label">Is this the same person who completed this form?</span>
               </Form.Label>
               <Col sm="6" className="align-self-center">
-                <div key="radio">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Is this the same person who completed this form?</legend>
                   {errors.clarification_contact && saved ? (
                     <Reminder message={errors.clarification_contact}>
                       <Form.Check
                         type="radio"
                         id="clarification-contact-radio-no"
                         inline
-                        style={{ color: "red", borderBottom: "1px solid red" }}
+                        style={{ color: "#b91c1c", borderBottom: "1px solid #b91c1c" }}
                         name="clarification_contact">
                         <Form.Check.Input
                           bsPrefix
@@ -1076,7 +1077,7 @@ const CohortForm = ({ ...props }) => {
                         type="radio"
                         id="clarification-contact-radio-yes"
                         inline
-                        style={{ color: "red", borderBottom: "1px solid red" }}
+                        style={{ color: "#b91c1c", borderBottom: "1px solid #b91c1c" }}
                         name="clarification_contact">
                         <Form.Check.Input
                           bsPrefix
@@ -1125,7 +1126,7 @@ const CohortForm = ({ ...props }) => {
                       <Form.Check.Label htmlFor="clarification-contact-radio-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                     </Form.Check>
                   )}
-                </div>
+                </fieldset>
               </Col>
               <Col sm="12">
                 <Person
@@ -1302,7 +1303,8 @@ const CohortForm = ({ ...props }) => {
                   {errors.eligible_gender_id && saved && <span className="text-danger ml-3">{errorMsg}</span>}
                 </Form.Label>
                 <Col sm="12">
-                  <div key="radio">
+                  <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                    <legend className="sr-only">Eligible sex</legend>
                     <Form.Check type="radio" className="pl-0" id="default-gender-all" name="eligible_gender_id">
                       <Form.Check.Input
                         bsPrefix
@@ -1336,7 +1338,7 @@ const CohortForm = ({ ...props }) => {
                       />
                       <Form.Check.Label htmlFor="default-gender-females" style={{ fontWeight: "normal" }}>Females only</Form.Check.Label>
                     </Form.Check>
-                  </div>
+                  </fieldset>
                 </Col>
               </Col>
               <Col sm="12" className="p-0 mb-3">
@@ -1407,7 +1409,7 @@ const CohortForm = ({ ...props }) => {
                     <Reminder message={errors.enrollment_total}>
                       <Form.Control
                         type="text"
-                        style={{ color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }}
+                        style={{ color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }}
                         name="enrollment_total"
                         value={cohort.enrollment_total}
                         onChange={(e) =>
@@ -1440,7 +1442,7 @@ const CohortForm = ({ ...props }) => {
                     <Reminder message={errors.enrollment_year_start}>
                       <Form.Control
                         type="text"
-                        style={{ color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }}
+                        style={{ color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }}
                         name="enrollment_year_start"
                         placeholder="YYYY"
                         value={cohort.enrollment_year_start}
@@ -1474,14 +1476,15 @@ const CohortForm = ({ ...props }) => {
                   Is enrollment ongoing?<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2" className="mt-3">
-                  <div key="radio">
+                  <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                    <legend className="sr-only">Is enrollment ongoing?</legend>
                     <Reminder message="Required Field" disabled={!(errors.enrollment_ongoing && saved)}>
                       <Form.Check
                         type="radio"
                         id="enrollment-ongoing-radio-no"
                         inline
                         style={
-                          errors.enrollment_ongoing && saved ? { color: "red", borderBottom: "1px solid red" } : {}
+                          errors.enrollment_ongoing && saved ? { color: "#b91c1c", borderBottom: "1px solid #b91c1c" } : {}
                         }
                         name="enrollment_ongoing">
                         <Form.Check.Input
@@ -1513,7 +1516,7 @@ const CohortForm = ({ ...props }) => {
                         id="enrollment-ongoing-radio-yes"
                         inline
                         style={
-                          errors.enrollment_ongoing && saved ? { color: "red", borderBottom: "1px solid red" } : {}
+                          errors.enrollment_ongoing && saved ? { color: "#b91c1c", borderBottom: "1px solid #b91c1c" } : {}
                         }
                         name="enrollment_ongoing">
                         <Form.Check.Input
@@ -1545,7 +1548,7 @@ const CohortForm = ({ ...props }) => {
                         <Form.Check.Label htmlFor="enrollment-ongoing-radio-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                       </Form.Check>
                     </Reminder>
-                  </div>
+                  </fieldset>
                 </Col>
               </Col>
               <Col sm="12" className="p-0 mb-1">
@@ -1557,7 +1560,7 @@ const CohortForm = ({ ...props }) => {
                     <input
                       style={
                         errors.enrollment_year_end && saved
-                          ? { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                          ? { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                           : { minWidth: "100px", maxWidth: "100px" }
                       }
                       className="form-control"
@@ -1597,7 +1600,7 @@ const CohortForm = ({ ...props }) => {
                     <Reminder message={errors.enrollment_target}>
                       <Form.Control
                         type="text"
-                        style={{ color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }}
+                        style={{ color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }}
                         name="enrollment_target"
                         value={cohort.enrollment_target}
                         onChange={(e) =>
@@ -1644,7 +1647,7 @@ const CohortForm = ({ ...props }) => {
                       type="text"
                       style={
                         errors.enrollment_year_complete && saved
-                          ? { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                          ? { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                           : { minWidth: "100px", maxWidth: "100px" }
                       }
                       name="enrollment_year_complete"
@@ -1689,7 +1692,7 @@ const CohortForm = ({ ...props }) => {
                         style={
                           !(errors.enrollment_age_min && saved)
                             ? { minWidth: "100px", maxWidth: "100px" }
-                            : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                            : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="enrollment_age_min"
                         value={cohort.enrollment_age_min}
@@ -1716,7 +1719,7 @@ const CohortForm = ({ ...props }) => {
                         style={
                           !(errors.enrollment_age_max && saved)
                             ? { minWidth: "100px", maxWidth: "100px" }
-                            : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                            : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="enrollment_age_max"
                         value={cohort.enrollment_age_max}
@@ -1748,7 +1751,7 @@ const CohortForm = ({ ...props }) => {
                       style={
                         !(errors.enrollment_age_median && saved)
                           ? { minWidth: "100px", maxWidth: "100px" }
-                          : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                          : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="enrollment_age_median"
                       value={cohort.enrollment_age_median}
@@ -1779,7 +1782,7 @@ const CohortForm = ({ ...props }) => {
                       style={
                         !(errors.enrollment_age_mean && saved)
                           ? { minWidth: "100px", maxWidth: "100px" }
-                          : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                          : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="enrollment_age_mean"
                       value={cohort.enrollment_age_mean}
@@ -1809,7 +1812,7 @@ const CohortForm = ({ ...props }) => {
                         style={
                           !(errors.current_age_min && saved)
                             ? { minWidth: "100px", maxWidth: "100px" }
-                            : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                            : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="current_age_min"
                         value={cohort.current_age_min}
@@ -1834,7 +1837,7 @@ const CohortForm = ({ ...props }) => {
                         style={
                           !(errors.current_age_max && saved)
                             ? { minWidth: "100px", maxWidth: "100px" }
-                            : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                            : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="current_age_max"
                         value={cohort.current_age_max}
@@ -1864,7 +1867,7 @@ const CohortForm = ({ ...props }) => {
                       style={
                         !(errors.current_age_median && saved)
                           ? { minWidth: "100px", maxWidth: "100px" }
-                          : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                          : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="current_age_median"
                       value={cohort.current_age_median}
@@ -1893,7 +1896,7 @@ const CohortForm = ({ ...props }) => {
                       style={
                         !(errors.current_age_mean && saved)
                           ? { minWidth: "100px", maxWidth: "100px" }
-                          : { color: "red", border: "1px solid red", minWidth: "100px", maxWidth: "100px" }
+                          : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="current_age_mean"
                       value={cohort.current_age_mean}
@@ -1930,7 +1933,7 @@ const CohortForm = ({ ...props }) => {
                   <Reminder message={errors.time_interval}>
                     <Form.Control
                       type="text"
-                      style={{ color: "red", border: "1px solid red" }}
+                      style={{ color: "#b91c1c", border: "1px solid #b91c1c" }}
                       placeholder="Max of 200 characters"
                       maxLength="200"
                       name="time_interval"
@@ -1964,7 +1967,7 @@ const CohortForm = ({ ...props }) => {
                   <Reminder message={errors.most_recent_year}>
                     <Form.Control
                       type="text"
-                      style={{ color: "red", border: "1px solid red" }}
+                      style={{ color: "#b91c1c", border: "1px solid #b91c1c" }}
                       name="most_recent_year"
                       value={cohort.most_recent_year}
                       onChange={(e) =>
@@ -2134,7 +2137,7 @@ const CohortForm = ({ ...props }) => {
                   <Reminder message={errors.data_collected_other_specify}>
                     <Form.Control
                       type="text"
-                      style={{ color: "red", border: "1px solid red" }}
+                      style={{ color: "#b91c1c", border: "1px solid #b91c1c" }}
                       name="data_collected_other_specify"
                       value={cohort.data_collected_other_specify}
                       placeholder="Max of 200 characters"
@@ -2419,7 +2422,7 @@ const CohortForm = ({ ...props }) => {
                   <Reminder message={errors.restrictions_other_specify}>
                     <Form.Control
                       type="text"
-                      style={{ color: "red", border: "1px solid red" }}
+                      style={{ color: "#b91c1c", border: "1px solid #b91c1c" }}
                       name="restrictions_other_specify"
                       value={cohort.restrictions_other_specify}
                       placeholder="Max of 200 characters"
@@ -2719,7 +2722,7 @@ const CohortForm = ({ ...props }) => {
                   <Reminder message={errors.strategy_other_specify}>
                     <Form.Control
                       type="text"
-                      style={{ color: "red", border: "1px solid red" }}
+                      style={{ color: "#b91c1c", border: "1px solid #b91c1c" }}
                       name="strategy_other_specify"
                       value={cohort.strategy_other_specify}
                       placeholder="Max of 200 characters"

--- a/client/src/components/CohortForm/CohortForm.js
+++ b/client/src/components/CohortForm/CohortForm.js
@@ -969,7 +969,7 @@ const CohortForm = ({ ...props }) => {
 
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                A.4a Person who completed the form<span style={{ color: "red" }}>*</span>
+                A.4a Person who completed the form<span className="error-text">*</span>
               </Form.Label>
               <Col sm="12">
                 <Person
@@ -991,7 +991,7 @@ const CohortForm = ({ ...props }) => {
             {/* A.4b Contact Person */}
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                A.4b Contact Person for Clarification of this form<span style={{ color: "red" }}>*</span>
+                A.4b Contact Person for Clarification of this form<span className="error-text">*</span>
               </Form.Label>
               <Form.Label column sm="5" style={{ fontWeight: "normal" }}>
                 <span className="required-label">Is this the same person who completed this form?</span>
@@ -1298,7 +1298,7 @@ const CohortForm = ({ ...props }) => {
               </Form.Label>
               <Col sm="12" className="p-0 mb-3">
                 <Form.Label column sm="12" style={{ fontWeight: "normal" }}>
-                  Eligible sex<span style={{ color: "red" }}>*</span>
+                  Eligible sex<span className="error-text">*</span>
                   {errors.eligible_gender_id && saved && <span className="text-danger ml-3">{errorMsg}</span>}
                 </Form.Label>
                 <Col sm="12">
@@ -1400,7 +1400,7 @@ const CohortForm = ({ ...props }) => {
               </Form.Label>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
-                  Total number of subjects enrolled to date<span style={{ color: "red" }}>*</span>
+                  Total number of subjects enrolled to date<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   {errors.enrollment_total && saved ? (
@@ -1433,7 +1433,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column md="6" sm="12" style={{ fontWeight: "normal" }}>
-                  Started in year<span style={{ color: "red" }}>*</span>
+                  Started in year<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   {errors.enrollment_year_start && saved ? (
@@ -1471,7 +1471,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column md="6" sm="12" style={{ fontWeight: "normal" }}>
-                  Is enrollment ongoing?<span style={{ color: "red" }}>*</span>
+                  Is enrollment ongoing?<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2" className="mt-3">
                   <div key="radio">
@@ -1550,7 +1550,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column md="6" sm="12" style={{ fontWeight: "normal" }}>
-                  Ended in year<span style={{ color: "red" }}>*</span>
+                  Ended in year<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   <Reminder message={errors.enrollment_year_end} disabled={!(errors.enrollment_year_end && saved)}>
@@ -1590,7 +1590,7 @@ const CohortForm = ({ ...props }) => {
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
                   If still enrolling, please specify the target number of plan to enroll
-                  <span style={{ color: "red" }}>*</span>
+                  <span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   {errors.enrollment_target && saved ? (
@@ -1634,7 +1634,7 @@ const CohortForm = ({ ...props }) => {
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
                   If still enrolling, please specify when you plan to complete enrollment
-                  <span style={{ color: "red" }}>*</span>
+                  <span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   <Reminder
@@ -1679,7 +1679,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
-                  Baseline age range of enrolled subjects<span style={{ color: "red" }}>*</span>
+                  Baseline age range of enrolled subjects<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="4">
                   <InputGroup>
@@ -1739,7 +1739,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
-                  Baseline Median age<span style={{ color: "red" }}>*</span>
+                  Baseline Median age<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   <Reminder message={errors.enrollment_age_median} disabled={!(errors.enrollment_age_median && saved)}>
@@ -1770,7 +1770,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
-                  Baseline Mean age<span style={{ color: "red" }}>*</span>
+                  Baseline Mean age<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   <Reminder message={errors.enrollment_age_mean} disabled={!(errors.enrollment_age_mean && saved)}>
@@ -1799,7 +1799,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
-                  Current age range of enrolled subjects<span style={{ color: "red" }}>*</span>
+                  Current age range of enrolled subjects<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="4">
                   <InputGroup>
@@ -1855,7 +1855,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
-                  Current Median age<span style={{ color: "red" }}>*</span>
+                  Current Median age<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   <Reminder message={errors.current_age_median} disabled={!(errors.current_age_median && saved)}>
@@ -1884,7 +1884,7 @@ const CohortForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="p-0 mb-1">
                 <Form.Label column sm="12" md="6" style={{ fontWeight: "normal" }}>
-                  Current Mean age<span style={{ color: "red" }}>*</span>
+                  Current Mean age<span className="error-text">*</span>
                 </Form.Label>
                 <Col sm="2">
                   <Reminder message={errors.current_age_mean} disabled={!(errors.current_age_mean && saved)}>
@@ -1923,7 +1923,7 @@ const CohortForm = ({ ...props }) => {
             <Form.Group as={Row}>
               <Form.Label column sm="12">
                 A.9 Specify the frequency of questionnaires, e.g, annually, every 2 years etc.
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
               </Form.Label>
               <Col sm="12">
                 {errors.time_interval && saved ? (
@@ -1957,7 +1957,7 @@ const CohortForm = ({ ...props }) => {
             {/* A.10 Most Recent Year Questionnaire Collected */}
             <Form.Group as={Row}>
               <Form.Label column sm="6">
-                A.10 Most recent year when questionnaire data were collected<span style={{ color: "red" }}>*</span>
+                A.10 Most recent year when questionnaire data were collected<span className="error-text">*</span>
               </Form.Label>
               <Col sm="2">
                 {errors.most_recent_year && saved ? (
@@ -1998,10 +1998,10 @@ const CohortForm = ({ ...props }) => {
             <Form.Group as={Row}>
               <Form.Label column sm="12">
                 A.11 How was information from the questionnaire administered/collected?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 <span className="font-weight-normal"> (Select all that apply)</span>
                 {errors.dataCollection && saved && (
-                  <span style={{ color: "red", marginLeft: "10px", fontWeight: "normal" }}>{errorMsg}</span>
+                  <span className="error-text" style={{ marginLeft: "10px", fontWeight: "normal" }}>{errorMsg}</span>
                 )}
               </Form.Label>
               <Col sm="12">
@@ -2184,10 +2184,10 @@ const CohortForm = ({ ...props }) => {
               <Form.Label column sm="12">
                 A.12 Does your cohort have any specific requirements or restrictions concerning participanting in
                 collaborative projects involving pooling of data or specimens or use of specimens in genomic studies?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 <span className="font-weight-normal"> (Select all that apply)</span>
                 {errors.requirements && saved && (
-                  <span style={{ color: "red", marginLeft: "10px", fontWeight: "normal" }}>{errorMsg}</span>
+                  <span className="error-text" style={{ marginLeft: "10px", fontWeight: "normal" }}>{errorMsg}</span>
                 )}
               </Form.Label>
               <Col sm="12">
@@ -2457,10 +2457,10 @@ const CohortForm = ({ ...props }) => {
             {/* A.13 Strategies Used */}
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                A.13 What strategies does your cohort use to engage participants?<span style={{ color: "red" }}>*</span>
+                A.13 What strategies does your cohort use to engage participants?<span className="error-text">*</span>
                 <span className="font-weight-normal"> (Select all that apply)</span>
                 {errors.strategy && saved && (
-                  <span style={{ color: "red", marginLeft: "10px", fontWeight: "normal" }}>{errorMsg}</span>
+                  <span className="error-text" style={{ marginLeft: "10px", fontWeight: "normal" }}>{errorMsg}</span>
                 )}
               </Form.Label>
               <Col sm="12">

--- a/client/src/components/CohortForm/CohortForm.js
+++ b/client/src/components/CohortForm/CohortForm.js
@@ -1411,6 +1411,7 @@ const CohortForm = ({ ...props }) => {
                         type="text"
                         style={{ color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }}
                         name="enrollment_total"
+                        aria-label="Total number of subjects enrolled to date"
                         value={cohort.enrollment_total}
                         onChange={(e) =>
                           !isReadOnly && dispatch(allactions.cohortActions.enrollment_total(e.target.value))
@@ -1423,6 +1424,7 @@ const CohortForm = ({ ...props }) => {
                       type="text"
                       style={{ minWidth: "100px", maxWidth: "100px" }}
                       name="enrollment_total"
+                      aria-label="Total number of subjects enrolled to date"
                       value={cohort.enrollment_total}
                       onChange={(e) =>
                         !isReadOnly && dispatch(allactions.cohortActions.enrollment_total(e.target.value))
@@ -1602,6 +1604,7 @@ const CohortForm = ({ ...props }) => {
                         type="text"
                         style={{ color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }}
                         name="enrollment_target"
+                        aria-label="Target number of subjects planned to enroll"
                         value={cohort.enrollment_target}
                         onChange={(e) =>
                           !isReadOnly && dispatch(allactions.cohortActions.enrollment_target(e.target.value))
@@ -1620,6 +1623,7 @@ const CohortForm = ({ ...props }) => {
                       type="text"
                       style={{ minWidth: "100px", maxWidth: "100px" }}
                       name="enrollment_target"
+                      aria-label="Target number of subjects planned to enroll"
                       value={cohort.enrollment_target}
                       onChange={(e) =>
                         !isReadOnly && dispatch(allactions.cohortActions.enrollment_target(e.target.value))
@@ -1695,6 +1699,7 @@ const CohortForm = ({ ...props }) => {
                             : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="enrollment_age_min"
+                        aria-label="Baseline minimum enrollment age"
                         value={cohort.enrollment_age_min}
                         onChange={(e) =>
                           !isReadOnly &&
@@ -1722,6 +1727,7 @@ const CohortForm = ({ ...props }) => {
                             : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="enrollment_age_max"
+                        aria-label="Baseline maximum enrollment age"
                         value={cohort.enrollment_age_max}
                         onChange={(e) =>
                           !isReadOnly &&
@@ -1754,6 +1760,7 @@ const CohortForm = ({ ...props }) => {
                           : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="enrollment_age_median"
+                      aria-label="Baseline median enrollment age"
                       value={cohort.enrollment_age_median}
                       onChange={(e) =>
                         !isReadOnly &&
@@ -1785,6 +1792,7 @@ const CohortForm = ({ ...props }) => {
                           : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="enrollment_age_mean"
+                      aria-label="Baseline mean enrollment age"
                       value={cohort.enrollment_age_mean}
                       onChange={(e) =>
                         !isReadOnly &&
@@ -1815,6 +1823,7 @@ const CohortForm = ({ ...props }) => {
                             : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="current_age_min"
+                        aria-label="Current minimum age of enrolled subjects"
                         value={cohort.current_age_min}
                         onChange={(e) =>
                           !isReadOnly &&
@@ -1840,6 +1849,7 @@ const CohortForm = ({ ...props }) => {
                             : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                         }
                         name="current_age_max"
+                        aria-label="Current maximum age of enrolled subjects"
                         value={cohort.current_age_max}
                         onChange={(e) =>
                           !isReadOnly &&
@@ -1870,6 +1880,7 @@ const CohortForm = ({ ...props }) => {
                           : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="current_age_median"
+                      aria-label="Current median age of enrolled subjects"
                       value={cohort.current_age_median}
                       onChange={(e) =>
                         !isReadOnly &&
@@ -1899,6 +1910,7 @@ const CohortForm = ({ ...props }) => {
                           : { color: "#b91c1c", border: "1px solid #b91c1c", minWidth: "100px", maxWidth: "100px" }
                       }
                       name="current_age_mean"
+                      aria-label="Current mean age of enrolled subjects"
                       value={cohort.current_age_mean}
                       onChange={(e) =>
                         !isReadOnly &&

--- a/client/src/components/CohortForm/CohortForm.js
+++ b/client/src/components/CohortForm/CohortForm.js
@@ -889,7 +889,7 @@ const CohortForm = ({ ...props }) => {
             onClick={() => setActivePanel(activePanel === "panelA" ? "" : "panelA")}
             panelTitle="Cohort Information">
             {/* A.1a Cohort Name */}
-            <Form.Group as={Row}>
+            <Form.Group as={Row} controlId="cohort-name">
               <Form.Label column sm="5">
                 A.1a Cohort Name
               </Form.Label>
@@ -899,7 +899,7 @@ const CohortForm = ({ ...props }) => {
             </Form.Group>
 
             {/* A.1b Cohort Abbreviation */}
-            <Form.Group as={Row}>
+            <Form.Group as={Row} controlId="cohort-acronym">
               <Form.Label column sm="5">
                 A.1b Cohort Abbreviation
               </Form.Label>
@@ -1031,7 +1031,7 @@ const CohortForm = ({ ...props }) => {
                             }
                           }}
                         />
-                        <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                        <Form.Check.Label htmlFor="clarification-contact-radio-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                       </Form.Check>
                     </Reminder>
                   ) : (
@@ -1066,7 +1066,7 @@ const CohortForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                      <Form.Check.Label htmlFor="clarification-contact-radio-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                     </Form.Check>
                   )}
 
@@ -1095,7 +1095,7 @@ const CohortForm = ({ ...props }) => {
                             }
                           }}
                         />
-                        <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                        <Form.Check.Label htmlFor="clarification-contact-radio-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                       </Form.Check>
                     </Reminder>
                   ) : (
@@ -1122,7 +1122,7 @@ const CohortForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                      <Form.Check.Label htmlFor="clarification-contact-radio-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                     </Form.Check>
                   )}
                 </div>
@@ -1241,7 +1241,7 @@ const CohortForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="default-completerName-check" style={{ fontWeight: "normal" }}>
                       Same as the person who completed the form(4a)
                     </Form.Check.Label>
                   </Form.Check>
@@ -1270,7 +1270,7 @@ const CohortForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="default-contacterName-check" style={{ fontWeight: "normal" }}>
                       Same as the contact person for clarification of this form(4b)
                     </Form.Check.Label>
                   </Form.Check>
@@ -1312,7 +1312,7 @@ const CohortForm = ({ ...props }) => {
                         checked={cohort.eligible_gender_id === 4}
                         onChange={() => !isReadOnly && removeEligbleGenderError(4)}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>All</Form.Check.Label>
+                      <Form.Check.Label htmlFor="default-gender-all" style={{ fontWeight: "normal" }}>All</Form.Check.Label>
                     </Form.Check>
                     <Form.Check type="radio" className="pl-0" id="default-gender-males" name="eligible_gender_id">
                       <Form.Check.Input
@@ -1323,7 +1323,7 @@ const CohortForm = ({ ...props }) => {
                         checked={cohort.eligible_gender_id === 2}
                         onChange={() => !isReadOnly && removeEligbleGenderError(2)}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Males only</Form.Check.Label>
+                      <Form.Check.Label htmlFor="default-gender-males" style={{ fontWeight: "normal" }}>Males only</Form.Check.Label>
                     </Form.Check>
                     <Form.Check type="radio" className="pl-0" id="default-gender-females" name="eligible_gender_id">
                       <Form.Check.Input
@@ -1334,7 +1334,7 @@ const CohortForm = ({ ...props }) => {
                         checked={cohort.eligible_gender_id === 1}
                         onChange={() => !isReadOnly && removeEligbleGenderError(1)}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Females only</Form.Check.Label>
+                      <Form.Check.Label htmlFor="default-gender-females" style={{ fontWeight: "normal" }}>Females only</Form.Check.Label>
                     </Form.Check>
                   </div>
                 </Col>
@@ -1355,7 +1355,7 @@ const CohortForm = ({ ...props }) => {
                           if (!isReadOnly) dispatch(allactions.cohortActions.eligible_disease(+e.target.checked));
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>
+                      <Form.Check.Label htmlFor="default-cancerSurvivors" style={{ fontWeight: "normal" }}>
                         Cancer survivors only, specify cancer site(s)
                       </Form.Check.Label>
                     </Form.Check>
@@ -1504,7 +1504,7 @@ const CohortForm = ({ ...props }) => {
                             }
                           }}
                         />
-                        <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                        <Form.Check.Label htmlFor="enrollment-ongoing-radio-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                       </Form.Check>
                     </Reminder>
                     <Reminder message="Required Field" disabled={!(errors.enrollment_ongoing && saved)}>
@@ -1542,7 +1542,7 @@ const CohortForm = ({ ...props }) => {
                             }
                           }}
                         />
-                        <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                        <Form.Check.Label htmlFor="enrollment-ongoing-radio-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                       </Form.Check>
                     </Reminder>
                   </div>
@@ -2031,7 +2031,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>In person</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-collected-in-person" style={{ fontWeight: "normal" }}>In person</Form.Check.Label>
                   </Form.Check>
                   <Form.Check type="checkbox" className="pl-0" id="default-collected-phone" name="data_collected_phone">
                     <Form.Check.Input
@@ -2054,7 +2054,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Phone interview</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-collected-phone" style={{ fontWeight: "normal" }}>Phone interview</Form.Check.Label>
                   </Form.Check>
                   <Form.Check type="checkbox" className="pl-0" id="default-collected-paper" name="data_collected_paper">
                     <Form.Check.Input
@@ -2077,7 +2077,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Self-administered via paper</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-collected-paper" style={{ fontWeight: "normal" }}>Self-administered via paper</Form.Check.Label>
                   </Form.Check>
                   <Form.Check type="checkbox" className="pl-0" id="default-collected-web" name="data_collected_web">
                     <Form.Check.Input
@@ -2100,7 +2100,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="default-collected-web" style={{ fontWeight: "normal" }}>
                       Self-administered via web-based device
                     </Form.Check.Label>
                   </Form.Check>
@@ -2127,7 +2127,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Other, please specify</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-collected-other" style={{ fontWeight: "normal" }}>Other, please specify</Form.Check.Label>
                   </Form.Check>
                 </div>
                 {saved && errors.data_collected_other_specify ? (
@@ -2216,7 +2216,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>None</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-require-none" style={{ fontWeight: "normal" }}>None</Form.Check.Label>
                   </Form.Check>
                   <Form.Check type="checkbox" className="pl-0" id="default-require-collab" name="requireCollab">
                     <Form.Check.Input
@@ -2242,7 +2242,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="default-require-collab" style={{ fontWeight: "normal" }}>
                       Require collaboration with cohort investigators
                     </Form.Check.Label>
                   </Form.Check>
@@ -2270,7 +2270,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Require IRB approvals</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-require-irb" style={{ fontWeight: "normal" }}>Require IRB approvals</Form.Check.Label>
                   </Form.Check>
                   <Form.Check type="checkbox" className="pl-0" id="default-require-data" name="requireData">
                     <Form.Check.Input
@@ -2296,7 +2296,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="default-require-data" style={{ fontWeight: "normal" }}>
                       Require data use agreements and/or material transfer agreement
                     </Form.Check.Label>
                   </Form.Check>
@@ -2324,7 +2324,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="default-restrict-geno-info" style={{ fontWeight: "normal" }}>
                       Restrictions in the consent related to genetic information
                     </Form.Check.Label>
                   </Form.Check>
@@ -2352,7 +2352,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="default-restrict-other-db" style={{ fontWeight: "normal" }}>
                       Restrictions in the consent related to linking to other databases
                     </Form.Check.Label>
                   </Form.Check>
@@ -2384,7 +2384,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Restrictions on commercial use</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-restrict-commercial" style={{ fontWeight: "normal" }}>Restrictions on commercial use</Form.Check.Label>
                   </Form.Check>
                   <Form.Check type="checkbox" className="pl-0" id="default-restrict-other" name="restrictOther">
                     <Form.Check.Input
@@ -2412,7 +2412,7 @@ const CohortForm = ({ ...props }) => {
                         )
                       }
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Other, please specify</Form.Check.Label>
+                    <Form.Check.Label htmlFor="default-restrict-other" style={{ fontWeight: "normal" }}>Other, please specify</Form.Check.Label>
                   </Form.Check>
                 </div>
                 {saved && errors.restrictions_other_specify ? (

--- a/client/src/components/CohortForm/Investigator/Investigator.js
+++ b/client/src/components/CohortForm/Investigator/Investigator.js
@@ -51,7 +51,7 @@ const Investigator = ({ id, name, institution, email, handleRemove, errors, disa
                 <Reminder message={errors[name]}>
                   <Form.Control
                     type="text"
-                    style={{ border: "1px solid red" }}
+                    style={{ border: "1px solid #b91c1c" }}
                     placeholder="Max of 100 characters"
                     maxLength="100"
                     name={name}
@@ -91,7 +91,7 @@ const Investigator = ({ id, name, institution, email, handleRemove, errors, disa
                 <Reminder message={errors[institution]}>
                   <Form.Control
                     type="text"
-                    style={{ border: "1px solid red" }}
+                    style={{ border: "1px solid #b91c1c" }}
                     placeholder="Max of 100 characters"
                     maxLength="100"
                     name={institution}
@@ -130,7 +130,7 @@ const Investigator = ({ id, name, institution, email, handleRemove, errors, disa
               {errors[email] && displayStyle ? (
                 <Reminder message={errors[email]}>
                   <Form.Control
-                    style={{ border: "1px solid red" }}
+                    style={{ border: "1px solid #b91c1c" }}
                     placeholder="Max of 100 characters"
                     maxLength="100"
                     type="email"

--- a/client/src/components/CohortForm/Investigator/Investigator.js
+++ b/client/src/components/CohortForm/Investigator/Investigator.js
@@ -43,7 +43,7 @@ const Investigator = ({ id, name, institution, email, handleRemove, errors, disa
           <Form.Group as={Row} className="mb-1">
             <Form.Label column sm="6" style={{ fontWeight: "normal" }}>
               <span className="pl-3">
-                Name<span style={{ color: "red" }}>*</span>
+                Name<span className="error-text">*</span>
               </span>
             </Form.Label>
             <Col sm="6">
@@ -83,7 +83,7 @@ const Investigator = ({ id, name, institution, email, handleRemove, errors, disa
           <Form.Group as={Row} className="mb-1">
             <Form.Label column sm="6" style={{ fontWeight: "normal" }}>
               <span className="pl-3">
-                Institution<span style={{ color: "red" }}>*</span>
+                Institution<span className="error-text">*</span>
               </span>
             </Form.Label>
             <Col sm="6">
@@ -123,7 +123,7 @@ const Investigator = ({ id, name, institution, email, handleRemove, errors, disa
           <Form.Group as={Row} className="mb-1">
             <Form.Label column sm="6" style={{ fontWeight: "normal" }}>
               <span className="pl-3">
-                Email<span style={{ color: "red" }}>*</span>
+                Email<span className="error-text">*</span>
               </span>
             </Form.Label>
             <Col sm="6">

--- a/client/src/components/CohortForm/Person/Person.js
+++ b/client/src/components/CohortForm/Person/Person.js
@@ -86,7 +86,7 @@ const Person = ({
     <>
       <Form.Group as={Row} className="mb-1">
         <Form.Label column sm={marginWidth} style={{ fontWeight: "normal" }}>
-          Name<span style={{ color: "red" }}>*</span>
+          Name<span className="error-text">*</span>
         </Form.Label>
         <Col sm={inputWidth}>
           {errors[name] && displayStyle ? (
@@ -131,7 +131,7 @@ const Person = ({
       </Form.Group>
       <Form.Group as={Row} className="mb-1">
         <Form.Label column sm={marginWidth} style={{ fontWeight: "normal" }}>
-          Position with the cohort<span style={{ color: "red" }}>*</span>
+          Position with the cohort<span className="error-text">*</span>
         </Form.Label>
         <Col sm={inputWidth}>
           {errors[position] && displayStyle ? (
@@ -243,7 +243,7 @@ const Person = ({
       </Form.Group>
       <Form.Group as={Row} className="mb-1">
         <Form.Label column sm={marginWidth} style={{ fontWeight: "normal" }}>
-          Email<span style={{ color: "red" }}>*</span>
+          Email<span className="error-text">*</span>
         </Form.Label>
         <Col sm={inputWidth}>
           {errors[email] && displayStyle ? (

--- a/client/src/components/CohortForm/Person/Person.js
+++ b/client/src/components/CohortForm/Person/Person.js
@@ -93,7 +93,7 @@ const Person = ({
             <Reminder message={errors[name]}>
               <Form.Control
                 type="text"
-                style={{ border: "1px solid red" }}
+                style={{ border: "1px solid #b91c1c" }}
                 placeholder="Max of 100 characters"
                 maxLength="100"
                 name={name}
@@ -138,7 +138,7 @@ const Person = ({
             <Reminder message={errors[position]}>
               <Form.Control
                 type="text"
-                style={{ border: "1px solid red" }}
+                style={{ border: "1px solid #b91c1c" }}
                 placeholder="Max of 100 characters"
                 maxLength="100"
                 name={position}
@@ -207,7 +207,7 @@ const Person = ({
               <Reminder message={errors[phone]}>
                 <Form.Control
                   type="text"
-                  style={{ border: "1px solid red", width: "75%" }}
+                  style={{ border: "1px solid #b91c1c", width: "75%" }}
                   placeholder={cohort[type] === "+1" ? "10 digits for USA" : "Max of 100 characters"}
                   maxLength="100"
                   name={phone}
@@ -250,7 +250,7 @@ const Person = ({
             <Reminder message={errors[email]}>
               <Form.Control
                 type="email"
-                style={{ border: "1px solid red" }}
+                style={{ border: "1px solid #b91c1c" }}
                 placeholder="Max of 100 characters"
                 maxLength="100"
                 name={email}

--- a/client/src/components/CohortList/CohortList.js
+++ b/client/src/components/CohortList/CohortList.js
@@ -141,7 +141,7 @@ class CohortList extends Component {
         {this.props.hasSelectAll ? (
           <span style={{ paddingLeft: "2rem" }}> All Cohorts</span>
         ) : (
-          <ul className="picked-options">{selectedList}</ul>
+          <ul className="picked-options">{selectedList.filter(Boolean)}</ul>
         )}
       </div>
     );

--- a/client/src/components/DataLinkageForm/DataLinkageForm.js
+++ b/client/src/components/DataLinkageForm/DataLinkageForm.js
@@ -571,7 +571,7 @@ const DataLinkageForm = ({ ...props }) => {
                     placement="right">
                     <Form.Control
                       type="text"
-                      style={{ border: "1px solid red" }}
+                      style={{ border: "1px solid #b91c1c" }}
                       name="haveDataLinkSpecify"
                       className="form-control"
                       value={dataLinkage.haveDataLinkSpecify}
@@ -700,7 +700,7 @@ const DataLinkageForm = ({ ...props }) => {
                     placement="right">
                     <Form.Control
                       type="text"
-                      style={{ border: "1px solid red" }}
+                      style={{ border: "1px solid #b91c1c" }}
                       name="haveHarmonizationSpecify"
                       className="form-control"
                       value={dataLinkage.haveHarmonizationSpecify}
@@ -1023,7 +1023,7 @@ const DataLinkageForm = ({ ...props }) => {
                 <Reminder message={errors.dataOnlineURL} disabled={!(errors.dataOnlineURL && saved)} placement="right">
                   <Form.Control
                     type="text"
-                    style={errors.dataOnlineURL && saved ? { border: "1px solid red" } : {}}
+                    style={errors.dataOnlineURL && saved ? { border: "1px solid #b91c1c" } : {}}
                     name="dataOnlineURL"
                     className="form-control"
                     value={dataLinkage.dataOnlineURL}
@@ -1244,7 +1244,7 @@ const DataLinkageForm = ({ ...props }) => {
                   <Reminder message={errors.createdRepoSpecify} disabled={!errors.createdRepoSpecify} placement="right">
                     <Form.Control
                       type="text"
-                      style={{ border: "1px solid red" }}
+                      style={{ border: "1px solid #b91c1c" }}
                       name="createdRepoSpecify"
                       className="form-control"
                       value={dataLinkage.createdRepoSpecify}

--- a/client/src/components/DataLinkageForm/DataLinkageForm.js
+++ b/client/src/components/DataLinkageForm/DataLinkageForm.js
@@ -485,7 +485,7 @@ const DataLinkageForm = ({ ...props }) => {
               <Col sm="12" className="align-self-center">
                 {saved && errors.haveDataLink ? (
                   <Reminder>
-                    <Form.Check type="radio" name="haveDataLink" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="haveDataLink-no" name="haveDataLink" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         type="radio"
@@ -499,11 +499,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                      <Form.Check.Label htmlFor="haveDataLink-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="haveDataLink" inline>
+                  <Form.Check type="radio" id="haveDataLink-no" name="haveDataLink" inline>
                     <Form.Check.Input
                       type="radio"
                       type="radio"
@@ -517,12 +517,12 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                    <Form.Check.Label htmlFor="haveDataLink-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                   </Form.Check>
                 )}
                 {saved && errors.haveDataLink ? (
                   <Reminder>
-                    <Form.Check type="radio" name="haveDataLink" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="haveDataLink-yes" name="haveDataLink" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         className="mr-2"
@@ -534,11 +534,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                      <Form.Check.Label htmlFor="haveDataLink-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="haveDataLink" inline>
+                  <Form.Check type="radio" id="haveDataLink-yes" name="haveDataLink" inline>
                     <Form.Check.Input
                       type="radio"
                       className="mr-2"
@@ -550,7 +550,7 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                    <Form.Check.Label htmlFor="haveDataLink-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
               </Col>
@@ -611,7 +611,7 @@ const DataLinkageForm = ({ ...props }) => {
               <Col sm="12" className="align-self-center">
                 {saved && errors.haveHarmonization ? (
                   <Reminder>
-                    <Form.Check type="radio" name="haveHarmonization" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="haveHarmonization-no" name="haveHarmonization" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         type="radio"
@@ -625,11 +625,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                      <Form.Check.Label htmlFor="haveHarmonization-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="haveHarmonization" inline>
+                  <Form.Check type="radio" id="haveHarmonization-no" name="haveHarmonization" inline>
                     <Form.Check.Input
                       type="radio"
                       type="radio"
@@ -643,12 +643,12 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                    <Form.Check.Label htmlFor="haveHarmonization-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                   </Form.Check>
                 )}
                 {saved && errors.haveHarmonization ? (
                   <Reminder>
-                    <Form.Check type="radio" name="haveHarmonization" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="haveHarmonization-yes" name="haveHarmonization" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         className="mr-2"
@@ -660,11 +660,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                      <Form.Check.Label htmlFor="haveHarmonization-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="haveHarmonization" inline>
+                  <Form.Check type="radio" id="haveHarmonization-yes" name="haveHarmonization" inline>
                     <Form.Check.Input
                       type="radio"
                       className="mr-2"
@@ -676,7 +676,7 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                    <Form.Check.Label htmlFor="haveHarmonization-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
               </Col>
@@ -735,7 +735,7 @@ const DataLinkageForm = ({ ...props }) => {
               <Col sm="12" className="align-self-center">
                 {saved && errors.haveDeposited ? (
                   <Reminder>
-                    <Form.Check type="radio" name="haveDeposited" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="haveDeposited-no" name="haveDeposited" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         type="radio"
@@ -751,11 +751,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                      <Form.Check.Label htmlFor="haveDeposited-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="haveDeposited" inline>
+                  <Form.Check type="radio" id="haveDeposited-no" name="haveDeposited" inline>
                     <Form.Check.Input
                       type="radio"
                       type="radio"
@@ -771,12 +771,12 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                    <Form.Check.Label htmlFor="haveDeposited-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                   </Form.Check>
                 )}
                 {saved && errors.haveDeposited ? (
                   <Reminder>
-                    <Form.Check type="radio" name="haveDeposited" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="haveDeposited-yes" name="haveDeposited" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         className="mr-2"
@@ -788,11 +788,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                      <Form.Check.Label htmlFor="haveDeposited-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="haveDeposited" inline>
+                  <Form.Check type="radio" id="haveDeposited-yes" name="haveDeposited" inline>
                     <Form.Check.Input
                       type="radio"
                       className="mr-2"
@@ -804,7 +804,7 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                    <Form.Check.Label htmlFor="haveDeposited-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
               </Col>
@@ -817,7 +817,7 @@ const DataLinkageForm = ({ ...props }) => {
               </Form.Label>
               <Col sm="12">
                 <div key="checkbox">
-                  <Form.Check className="pl-0" name="dbGaP">
+                  <Form.Check className="pl-0" id="dbGaP-checkbox" name="dbGaP">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -831,10 +831,10 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>dbGaP</Form.Check.Label>
+                    <Form.Check.Label htmlFor="dbGaP-checkbox" style={{ fontWeight: "normal" }}>dbGaP</Form.Check.Label>
                   </Form.Check>
 
-                  <Form.Check className="pl-0" name="BioLINCC">
+                  <Form.Check className="pl-0" id="BioLINCC-checkbox" name="BioLINCC">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -848,10 +848,10 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>BioLINCC</Form.Check.Label>
+                    <Form.Check.Label htmlFor="BioLINCC-checkbox" style={{ fontWeight: "normal" }}>BioLINCC</Form.Check.Label>
                   </Form.Check>
 
-                  <Form.Check className="pl-0" name="otherRepo">
+                  <Form.Check className="pl-0" id="otherRepo-checkbox" name="otherRepo">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -865,7 +865,7 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Other Repo</Form.Check.Label>
+                    <Form.Check.Label htmlFor="otherRepo-checkbox" style={{ fontWeight: "normal" }}>Other Repo</Form.Check.Label>
                   </Form.Check>
                 </div>
               </Col>
@@ -882,7 +882,7 @@ const DataLinkageForm = ({ ...props }) => {
               <Col sm="12" className="align-self-center">
                 {saved && errors.dataOnline ? (
                   <Reminder>
-                    <Form.Check type="radio" name="dataOnline" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="dataOnline-no" name="dataOnline" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         type="radio"
@@ -902,11 +902,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                      <Form.Check.Label htmlFor="dataOnline-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="dataOnline" inline>
+                  <Form.Check type="radio" id="dataOnline-no" name="dataOnline" inline>
                     <Form.Check.Input
                       type="radio"
                       type="radio"
@@ -926,15 +926,16 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                    <Form.Check.Label htmlFor="dataOnline-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                   </Form.Check>
                 )}
                 <Reminder disabled={!(saved && errors.dataOnline)}>
                   <Form.Check
                     type="radio"
+                    id="dataOnline-yes"
                     name="dataOnline"
                     inline
-                    style={saved && errors.dataOnline ? { color: "red" } : {}}>
+                    className={saved && errors.dataOnline ? "error-text" : ""}>
                     <Form.Check.Input
                       type="radio"
                       className="mr-2"
@@ -954,7 +955,7 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                    <Form.Check.Label htmlFor="dataOnline-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 </Reminder>
               </Col>
@@ -1148,7 +1149,7 @@ const DataLinkageForm = ({ ...props }) => {
               <Col sm="12" className="align-self-center">
                 {saved && errors.createdRepo ? (
                   <Reminder>
-                    <Form.Check type="radio" name="createdRepo" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="createdRepo-no" name="createdRepo" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         type="radio"
@@ -1162,11 +1163,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                      <Form.Check.Label htmlFor="createdRepo-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="createdRepo" inline>
+                  <Form.Check type="radio" id="createdRepo-no" name="createdRepo" inline>
                     <Form.Check.Input
                       type="radio"
                       type="radio"
@@ -1180,12 +1181,12 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                    <Form.Check.Label htmlFor="createdRepo-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                   </Form.Check>
                 )}
                 {saved && errors.createdRepo ? (
                   <Reminder>
-                    <Form.Check type="radio" name="createdRepo" inline style={{ color: "red" }}>
+                    <Form.Check type="radio" id="createdRepo-yes" name="createdRepo" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
                         className="mr-2"
@@ -1197,11 +1198,11 @@ const DataLinkageForm = ({ ...props }) => {
                           }
                         }}
                       />
-                      <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                      <Form.Check.Label htmlFor="createdRepo-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                     </Form.Check>
                   </Reminder>
                 ) : (
-                  <Form.Check type="radio" name="createdRepo" inline>
+                  <Form.Check type="radio" id="createdRepo-yes" name="createdRepo" inline>
                     <Form.Check.Input
                       type="radio"
                       className="mr-2"
@@ -1213,7 +1214,7 @@ const DataLinkageForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                    <Form.Check.Label htmlFor="createdRepo-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
               </Col>

--- a/client/src/components/DataLinkageForm/DataLinkageForm.js
+++ b/client/src/components/DataLinkageForm/DataLinkageForm.js
@@ -490,7 +490,6 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check type="radio" id="haveDataLink-no" name="haveDataLink" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
-                        type="radio"
                         className="mr-2"
                         checked={dataLinkage.haveDataLink === 0}
                         onClick={() => {
@@ -507,7 +506,6 @@ const DataLinkageForm = ({ ...props }) => {
                 ) : (
                   <Form.Check type="radio" id="haveDataLink-no" name="haveDataLink" inline>
                     <Form.Check.Input
-                      type="radio"
                       type="radio"
                       className="mr-2"
                       checked={dataLinkage.haveDataLink === 0}
@@ -619,7 +617,6 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check type="radio" id="haveHarmonization-no" name="haveHarmonization" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
-                        type="radio"
                         className="mr-2"
                         checked={dataLinkage.haveHarmonization === 0}
                         onClick={() => {
@@ -636,7 +633,6 @@ const DataLinkageForm = ({ ...props }) => {
                 ) : (
                   <Form.Check type="radio" id="haveHarmonization-no" name="haveHarmonization" inline>
                     <Form.Check.Input
-                      type="radio"
                       type="radio"
                       className="mr-2"
                       checked={dataLinkage.haveHarmonization === 0}
@@ -746,7 +742,6 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check type="radio" id="haveDeposited-no" name="haveDeposited" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
-                        type="radio"
                         className="mr-2"
                         checked={dataLinkage.haveDeposited === 0}
                         onClick={() => {
@@ -765,7 +760,6 @@ const DataLinkageForm = ({ ...props }) => {
                 ) : (
                   <Form.Check type="radio" id="haveDeposited-no" name="haveDeposited" inline>
                     <Form.Check.Input
-                      type="radio"
                       type="radio"
                       className="mr-2"
                       checked={dataLinkage.haveDeposited === 0}
@@ -896,7 +890,6 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check type="radio" id="dataOnline-no" name="dataOnline" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
-                        type="radio"
                         className="mr-2"
                         checked={dataLinkage.dataOnline === 0}
                         onClick={() => {
@@ -919,7 +912,6 @@ const DataLinkageForm = ({ ...props }) => {
                 ) : (
                   <Form.Check type="radio" id="dataOnline-no" name="dataOnline" inline>
                     <Form.Check.Input
-                      type="radio"
                       type="radio"
                       className="mr-2"
                       checked={dataLinkage.dataOnline === 0}
@@ -1166,7 +1158,6 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check type="radio" id="createdRepo-no" name="createdRepo" inline className="error-text">
                       <Form.Check.Input
                         type="radio"
-                        type="radio"
                         className="mr-2"
                         checked={dataLinkage.createdRepo === 0}
                         onClick={() => {
@@ -1183,7 +1174,6 @@ const DataLinkageForm = ({ ...props }) => {
                 ) : (
                   <Form.Check type="radio" id="createdRepo-no" name="createdRepo" inline>
                     <Form.Check.Input
-                      type="radio"
                       type="radio"
                       className="mr-2"
                       checked={dataLinkage.createdRepo === 0}

--- a/client/src/components/DataLinkageForm/DataLinkageForm.js
+++ b/client/src/components/DataLinkageForm/DataLinkageForm.js
@@ -483,6 +483,8 @@ const DataLinkageForm = ({ ...props }) => {
               </Form.Label>
 
               <Col sm="12" className="align-self-center">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Have you linked your cohort data to any other existing databases?</legend>
                 {saved && errors.haveDataLink ? (
                   <Reminder>
                     <Form.Check type="radio" id="haveDataLink-no" name="haveDataLink" inline className="error-text">
@@ -553,6 +555,7 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check.Label htmlFor="haveDataLink-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
+                </fieldset>
               </Col>
             </Form>
 
@@ -609,6 +612,8 @@ const DataLinkageForm = ({ ...props }) => {
               </Form.Label>
 
               <Col sm="12" className="align-self-center">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Have you participated in projects that required cross-cohort data harmonization?</legend>
                 {saved && errors.haveHarmonization ? (
                   <Reminder>
                     <Form.Check type="radio" id="haveHarmonization-no" name="haveHarmonization" inline className="error-text">
@@ -679,6 +684,7 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check.Label htmlFor="haveHarmonization-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
+                </fieldset>
               </Col>
             </Form>
 
@@ -733,6 +739,8 @@ const DataLinkageForm = ({ ...props }) => {
                 )}
               </Form.Label>
               <Col sm="12" className="align-self-center">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Have you deposited data in an NIH sponsored data repository?</legend>
                 {saved && errors.haveDeposited ? (
                   <Reminder>
                     <Form.Check type="radio" id="haveDeposited-no" name="haveDeposited" inline className="error-text">
@@ -807,6 +815,7 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check.Label htmlFor="haveDeposited-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
+                </fieldset>
               </Col>
             </Form>
 
@@ -880,6 +889,8 @@ const DataLinkageForm = ({ ...props }) => {
               </Form.Label>
 
               <Col sm="12" className="align-self-center">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Is your procedure for requesting data displayed online?</legend>
                 {saved && errors.dataOnline ? (
                   <Reminder>
                     <Form.Check type="radio" id="dataOnline-no" name="dataOnline" inline className="error-text">
@@ -958,6 +969,7 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check.Label htmlFor="dataOnline-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 </Reminder>
+                </fieldset>
               </Col>
             </Form>
 
@@ -1147,6 +1159,8 @@ const DataLinkageForm = ({ ...props }) => {
               </Form.Label>
 
               <Col sm="12" className="align-self-center">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Have you created your own data enclave or a public-facing data repository?</legend>
                 {saved && errors.createdRepo ? (
                   <Reminder>
                     <Form.Check type="radio" id="createdRepo-no" name="createdRepo" inline className="error-text">
@@ -1217,6 +1231,7 @@ const DataLinkageForm = ({ ...props }) => {
                     <Form.Check.Label htmlFor="createdRepo-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                   </Form.Check>
                 )}
+                </fieldset>
               </Col>
             </Form>
 

--- a/client/src/components/DataLinkageForm/DataLinkageForm.js
+++ b/client/src/components/DataLinkageForm/DataLinkageForm.js
@@ -476,7 +476,7 @@ const DataLinkageForm = ({ ...props }) => {
               <Form.Label column sm="12">
                 F.1 Have you linked your cohort data to any other existing databases (e.g., Center for Medicare and
                 Medicaid Services, State or Surveillance, Epidemiology and End Results (SEER) Cancer Registries)?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 {saved && errors.haveDataLink && (
                   <span className="text-danger ml-3 font-weight-normal">Required Field</span>
                 )}
@@ -602,7 +602,7 @@ const DataLinkageForm = ({ ...props }) => {
             <Form as={Row}>
               <Form.Label column sm="12">
                 F.2 Have you participated in projects that required cross-cohort data harmonization?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 {saved && errors.haveHarmonization && (
                   <span className="text-danger ml-3 font-weight-normal">Required Field</span>
                 )}
@@ -727,7 +727,7 @@ const DataLinkageForm = ({ ...props }) => {
 
             <Form as={Row}>
               <Form.Label column sm="12">
-                F.3 Have you deposited data in an NIH sponsored data repository?<span style={{ color: "red" }}>*</span>
+                F.3 Have you deposited data in an NIH sponsored data repository?<span className="error-text">*</span>
                 {saved && errors.haveDeposited && (
                   <span className="text-danger ml-3 font-weight-normal">Required Field</span>
                 )}
@@ -873,7 +873,7 @@ const DataLinkageForm = ({ ...props }) => {
 
             <Form as={Row}>
               <Form.Label column sm="12">
-                F.4 Is your procedure for requesting data displayed online?<span style={{ color: "red" }}>*</span>
+                F.4 Is your procedure for requesting data displayed online?<span className="error-text">*</span>
                 {saved && errors.dataOnline && (
                   <span className="text-danger ml-3 font-weight-normal">Required Field</span>
                 )}
@@ -1140,7 +1140,7 @@ const DataLinkageForm = ({ ...props }) => {
             <Form as={Row}>
               <Form.Label column sm="12">
                 F.5 Have you created your own data enclave or a public-facing data repository?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 {saved && errors.createdRepo && (
                   <span className="text-danger ml-3 font-weight-normal">Required Field</span>
                 )}

--- a/client/src/components/Details/Details.js
+++ b/client/src/components/Details/Details.js
@@ -1661,14 +1661,14 @@ class Details extends Component {
           <div className="filter-block home col-md-12">
             <div className="row" style={{ display: "flex", height: "35px" }}>
               <div id="tableControls" className="" style={{ paddingLeft: "15px" }}>
-                <ul className="table-controls">
+                <div className="table-controls">
                   <FloatingSubmit
                     onClick={this.handleComparasion}
                     align="true"
                     placement="top"
                     values={this.state.selected}
                   />
-                </ul>
+                </div>
               </div>
               <div id="tableExport" style={{ paddingLeft: "1rem", paddingTop: "7px" }}>
                 <Workbook

--- a/client/src/components/Details/Details.js
+++ b/client/src/components/Details/Details.js
@@ -1602,7 +1602,7 @@ class Details extends Component {
             <td>
               <Link to={url} onClick={this.saveHistory}>
                 {item.cohort_name}
-                <span style={{ color: "red" }}>{item.outdated ? "*" : ""}</span>
+                <span className="error-text">{item.outdated ? "*" : ""}</span>
               </Link>
             </td>
             <td>
@@ -1729,7 +1729,7 @@ class Details extends Component {
           <div className="filter-block home col-md-12">
             <div className="row" style={{ display: "flex" }}>
               <div style={{ paddingTop: "7px", paddingLeft: "10px" }}>
-                <span style={{ color: "red" }}>*</span>Indicates cohort profile has not been updated for at least 2
+                <span className="error-text">*</span>Indicates cohort profile has not been updated for at least 2
                 years or will not have future updates.
               </div>
               <div style={{ marginLeft: "auto", paddingRight: "1rem", paddingTop: "7px" }}>

--- a/client/src/components/EditCohort/EditCohort.js
+++ b/client/src/components/EditCohort/EditCohort.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
-import AccessibleSelect from "../controls/AccessibleSelect";
+import Select from "../controls/Select";
 import { connect } from "react-redux";
 import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
 import Messenger from "../Snackbar/Snackbar";
@@ -416,7 +416,7 @@ class EditCohort extends Component {
                       <Form.Label className="error-text"> {this.state.list_error}</Form.Label>
                     )}
                     <div style={{ width: "90%" }}>
-                      <AccessibleSelect
+                      <Select
                         inputId="edit_cohort_select"
                         name="cohort"
                         value={this.state.cohort}
@@ -469,7 +469,7 @@ class EditCohort extends Component {
                       <Form.Label className="error-text"> {this.state.type_error}</Form.Label>
                     )}
                     <div style={{ width: "90%" }}>
-                      <AccessibleSelect
+                      <Select
                         inputId="cu_type"
                         name="type"
                         value={this.state.type}
@@ -487,7 +487,7 @@ class EditCohort extends Component {
                       Cohort Owner(s)
                     </Form.Label>
                     <div style={{ width: "90%" }}>
-                      <AccessibleSelect
+                      <Select
                         inputId="cu_organization"
                         name="owners"
                         isMulti

--- a/client/src/components/EditCohort/EditCohort.js
+++ b/client/src/components/EditCohort/EditCohort.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
-import Select from "react-select";
+import AccessibleSelect from "../controls/AccessibleSelect";
 import { connect } from "react-redux";
 import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
 import Messenger from "../Snackbar/Snackbar";
@@ -409,14 +409,15 @@ class EditCohort extends Component {
                 <Form onSubmit={this.handleSubmit}>
                   <p id="ctl11_rg_errorMsg" className="bg-danger"></p>
                   <Form.Group id="ctl11_div_cohortList">
-                    <Form.Label className="oneLineLabel" htmlFor="cu_firstName">
-                      Cohort<span style={{ color: "red" }}>*</span>
+                    <Form.Label className="oneLineLabel" htmlFor="edit_cohort_select">
+                      Cohort<span className="error-text">*</span>
                     </Form.Label>
                     {this.state.list_error !== "" && (
-                      <Form.Label style={{ color: "red" }}> {this.state.list_error}</Form.Label>
+                      <Form.Label className="error-text"> {this.state.list_error}</Form.Label>
                     )}
                     <div style={{ width: "90%" }}>
-                      <Select
+                      <AccessibleSelect
+                        inputId="edit_cohort_select"
                         name="cohort"
                         value={this.state.cohort}
                         options={this.state.cohortList.map((e) => {
@@ -431,7 +432,7 @@ class EditCohort extends Component {
                       Cohort Name
                     </Form.Label>
                     {this.state.name_error !== "" && (
-                      <Form.Label style={{ color: "red" }}> {this.state.name_error}</Form.Label>
+                      <Form.Label className="error-text"> {this.state.name_error}</Form.Label>
                     )}
                     <input
                       className="form-control"
@@ -448,7 +449,7 @@ class EditCohort extends Component {
                       Cohort Acronym
                     </Form.Label>
                     {this.state.acronym_error !== "" && (
-                      <Form.Label style={{ color: "red" }}> {this.state.acronym_error}</Form.Label>
+                      <Form.Label className="error-text"> {this.state.acronym_error}</Form.Label>
                     )}
                     <input
                       className="form-control"
@@ -462,13 +463,14 @@ class EditCohort extends Component {
                   </Form.Group>
                   <Form.Group id="ctl11_div_cohortType">
                     <Form.Label className="oneLineLabel" htmlFor="cu_type">
-                      Cohort Type<span style={{ color: "red" }}>*</span>
+                      Cohort Type<span className="error-text">*</span>
                     </Form.Label>
                     {this.state.type_error !== "" && (
-                      <Form.Label style={{ color: "red" }}> {this.state.type_error}</Form.Label>
+                      <Form.Label className="error-text"> {this.state.type_error}</Form.Label>
                     )}
                     <div style={{ width: "90%" }}>
-                      <Select
+                      <AccessibleSelect
+                        inputId="cu_type"
                         name="type"
                         value={this.state.type}
                         options={[
@@ -485,9 +487,10 @@ class EditCohort extends Component {
                       Cohort Owner(s)
                     </Form.Label>
                     <div style={{ width: "90%" }}>
-                      <Select
+                      <AccessibleSelect
+                        inputId="cu_organization"
                         name="owners"
-                        isMulti="true"
+                        isMulti
                         value={this.state.cohortOwners}
                         options={this.state.ownerOptions}
                         onChange={this.handleMultiChange}
@@ -500,7 +503,7 @@ class EditCohort extends Component {
                       Notes{" "}
                     </Form.Label>
                     {this.state.notes_error !== "" && (
-                      <Form.Label style={{ color: "red", paddingLeft: "5px" }}> {this.state.notes_error}</Form.Label>
+                      <Form.Label className="error-text" style={{ paddingLeft: "5px" }}> {this.state.notes_error}</Form.Label>
                     )}
                     <textarea
                       className="form-control"

--- a/client/src/components/EnrollmentCounts/EnrollmentCountsForm.js
+++ b/client/src/components/EnrollmentCounts/EnrollmentCountsForm.js
@@ -1274,7 +1274,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
             {/* B.2 Most Recent Date Enrollment */}
             <Form.Group as={Row}>
               <Form.Label column sm="5">
-                B.2 Most recent date enrollment counts were confirmed<span style={{ color: "red" }}>*</span>
+                B.2 Most recent date enrollment counts were confirmed<span className="error-text">*</span>
               </Form.Label>
               <Col sm="3">
                 {errors.mostRecentDate && saved ? (

--- a/client/src/components/EnrollmentCounts/EnrollmentCountsForm.js
+++ b/client/src/components/EnrollmentCounts/EnrollmentCountsForm.js
@@ -325,40 +325,40 @@ const EnrollmentCountsForm = ({ ...props }) => {
               </Col>
               <Col sm="12">
                 <div className="table-responsive">
-                  <Table bordered condensed className="table-valign-middle">
+                  <Table bordered condensed className="table-valign-middle" aria-label="Enrollment counts by racial category, ethnicity, and sex">
                     <thead>
                       <tr>
-                        <th rowSpan="3" style={{ fontSize: "1.5rem", paddingRight: "0", width: "15%" }}>
+                        <th scope="col" rowSpan="3" style={{ fontSize: "1.5rem", paddingRight: "0", width: "15%" }}>
                           Racial Categories
                         </th>
-                        <th colSpan="9" style={{ textAlign: "center" }}>
+                        <th scope="colgroup" colSpan="9" style={{ textAlign: "center" }}>
                           Ethnic Categories
                         </th>
-                        <th rowSpan="3" style={{ width: "10%", textAlign: "center" }}>
+                        <th scope="col" rowSpan="3" style={{ width: "10%", textAlign: "center" }}>
                           Total
                         </th>
                       </tr>
                       <tr>
-                        <th colSpan="3" style={{ textAlign: "center" }}>
+                        <th scope="colgroup" colSpan="3" style={{ textAlign: "center" }}>
                           Not Hispanic or Latino
                         </th>
-                        <th colSpan="3" style={{ textAlign: "center" }}>
+                        <th scope="colgroup" colSpan="3" style={{ textAlign: "center" }}>
                           Hispanic or Latino
                         </th>
-                        <th colSpan="3" style={{ textAlign: "center" }}>
+                        <th scope="colgroup" colSpan="3" style={{ textAlign: "center" }}>
                           Unknown/Not Reported Ethnicity
                         </th>
                       </tr>
                       <tr>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Females</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Males</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Unknown/Not Reported</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Females</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Males</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Unknown/Not Reported</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Females</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Males</th>
-                        <th style={{ fontSize: "1.4rem", textAlign: "center" }}>Unknown/Not Reported</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Females</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Males</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Unknown/Not Reported</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Females</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Males</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Unknown/Not Reported</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Females</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Males</th>
+                        <th scope="col" style={{ fontSize: "1.4rem", textAlign: "center" }}>Unknown/Not Reported</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -370,6 +370,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="111"
+                            aria-label="American Indian / Alaska Native - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["111"] || 0}
                             onChange={(e) => updateCells("111", e.target.value)}
@@ -382,6 +383,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="112"
+                            aria-label="American Indian / Alaska Native - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["112"] || 0}
                             onChange={(e) => updateCells("112", e.target.value)}
@@ -394,6 +396,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="113"
+                            aria-label="American Indian / Alaska Native - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["113"] || 0}
                             onChange={(e) => updateCells("113", e.target.value)}
@@ -406,6 +409,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="121"
+                            aria-label="American Indian / Alaska Native - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["121"] || 0}
                             onChange={(e) => updateCells("121", e.target.value)}
@@ -418,6 +422,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="122"
+                            aria-label="American Indian / Alaska Native - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["122"] || 0}
                             onChange={(e) => updateCells("122", e.target.value)}
@@ -430,6 +435,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="123"
+                            aria-label="American Indian / Alaska Native - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["123"] || 0}
                             onChange={(e) => updateCells("123", e.target.value)}
@@ -442,6 +448,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="131"
+                            aria-label="American Indian / Alaska Native - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["131"] || 0}
                             onChange={(e) => updateCells("131", e.target.value)}
@@ -454,6 +461,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="132"
+                            aria-label="American Indian / Alaska Native - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["132"] || 0}
                             onChange={(e) => updateCells("132", e.target.value)}
@@ -466,6 +474,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="133"
+                            aria-label="American Indian / Alaska Native - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["133"] || 0}
                             onChange={(e) => updateCells("133", e.target.value)}
@@ -478,6 +487,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="141"
+                            aria-label="American Indian / Alaska Native - Row Total"
                             min="0"
                             value={enrollmentCount["141"] || 0}
                           />
@@ -491,6 +501,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="211"
+                            aria-label="Asian - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["211"] || 0}
                             onChange={(e) => updateCells("211", e.target.value)}
@@ -502,6 +513,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="212"
+                            aria-label="Asian - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["212"] || 0}
                             onChange={(e) => updateCells("212", e.target.value)}
@@ -513,6 +525,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="213"
+                            aria-label="Asian - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["213"] || 0}
                             onChange={(e) => updateCells("213", e.target.value)}
@@ -524,6 +537,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="221"
+                            aria-label="Asian - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["221"] || 0}
                             onChange={(e) => updateCells("221", e.target.value)}
@@ -535,6 +549,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="222"
+                            aria-label="Asian - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["222"] || 0}
                             onChange={(e) => updateCells("222", e.target.value)}
@@ -546,6 +561,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="223"
+                            aria-label="Asian - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["223"] || 0}
                             onChange={(e) => updateCells("223", e.target.value)}
@@ -557,6 +573,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="231"
+                            aria-label="Asian - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["231"] || 0}
                             onChange={(e) => updateCells("231", e.target.value)}
@@ -568,6 +585,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="232"
+                            aria-label="Asian - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["232"] || 0}
                             onChange={(e) => updateCells("232", e.target.value)}
@@ -579,6 +597,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="233"
+                            aria-label="Asian - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["233"] || 0}
                             onChange={(e) => updateCells("233", e.target.value)}
@@ -591,6 +610,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="241"
+                            aria-label="Asian - Row Total"
                             min="0"
                             value={enrollmentCount["241"] || 0}
                           />
@@ -604,6 +624,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="311"
+                            aria-label="Native Hawaiian or other Pacific Islander - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["311"] || 0}
                             onChange={(e) => updateCells("311", e.target.value)}
@@ -615,6 +636,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="312"
+                            aria-label="Native Hawaiian or other Pacific Islander - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["312"] || 0}
                             onChange={(e) => updateCells("312", e.target.value)}
@@ -626,6 +648,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="313"
+                            aria-label="Native Hawaiian or other Pacific Islander - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["313"] || 0}
                             onChange={(e) => updateCells("313", e.target.value)}
@@ -637,6 +660,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="321"
+                            aria-label="Native Hawaiian or other Pacific Islander - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["321"] || 0}
                             onChange={(e) => updateCells("321", e.target.value)}
@@ -648,6 +672,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="322"
+                            aria-label="Native Hawaiian or other Pacific Islander - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["322"] || 0}
                             onChange={(e) => updateCells("322", e.target.value)}
@@ -659,6 +684,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="323"
+                            aria-label="Native Hawaiian or other Pacific Islander - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["323"] || 0}
                             onChange={(e) => updateCells("323", e.target.value)}
@@ -670,6 +696,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="331"
+                            aria-label="Native Hawaiian or other Pacific Islander - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["331"] || 0}
                             onChange={(e) => updateCells("331", e.target.value)}
@@ -681,6 +708,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="332"
+                            aria-label="Native Hawaiian or other Pacific Islander - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["332"] || 0}
                             onChange={(e) => updateCells("332", e.target.value)}
@@ -692,6 +720,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="333"
+                            aria-label="Native Hawaiian or other Pacific Islander - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["333"] || 0}
                             onChange={(e) => updateCells("333", e.target.value)}
@@ -704,6 +733,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="341"
+                            aria-label="Native Hawaiian or other Pacific Islander - Row Total"
                             min="0"
                             value={enrollmentCount["341"] || 0}
                           />
@@ -717,6 +747,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="411"
+                            aria-label="Black or African American - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["411"] || 0}
                             onChange={(e) => updateCells("411", e.target.value)}
@@ -728,6 +759,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="412"
+                            aria-label="Black or African American - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["412"] || 0}
                             onChange={(e) => updateCells("412", e.target.value)}
@@ -739,6 +771,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="413"
+                            aria-label="Black or African American - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["413"] || 0}
                             onChange={(e) => updateCells("413", e.target.value)}
@@ -750,6 +783,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="421"
+                            aria-label="Black or African American - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["421"] || 0}
                             onChange={(e) => updateCells("421", e.target.value)}
@@ -761,6 +795,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="422"
+                            aria-label="Black or African American - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["422"] || 0}
                             onChange={(e) => updateCells("422", e.target.value)}
@@ -772,6 +807,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="423"
+                            aria-label="Black or African American - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["423"] || 0}
                             onChange={(e) => updateCells("423", e.target.value)}
@@ -783,6 +819,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="431"
+                            aria-label="Black or African American - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["431"] || 0}
                             onChange={(e) => updateCells("431", e.target.value)}
@@ -794,6 +831,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="432"
+                            aria-label="Black or African American - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["432"] || 0}
                             onChange={(e) => updateCells("432", e.target.value)}
@@ -805,6 +843,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="433"
+                            aria-label="Black or African American - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["433"] || 0}
                             onChange={(e) => updateCells("433", e.target.value)}
@@ -817,6 +856,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="441"
+                            aria-label="Black or African American - Row Total"
                             min="0"
                             value={enrollmentCount["441"] || 0}
                           />
@@ -830,6 +870,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="511"
+                            aria-label="White - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["511"] || 0}
                             onChange={(e) => updateCells("511", e.target.value)}
@@ -841,6 +882,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="512"
+                            aria-label="White - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["512"] || 0}
                             onChange={(e) => updateCells("512", e.target.value)}
@@ -852,6 +894,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="513"
+                            aria-label="White - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["513"] || 0}
                             onChange={(e) => updateCells("513", e.target.value)}
@@ -863,6 +906,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="521"
+                            aria-label="White - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["521"] || 0}
                             onChange={(e) => updateCells("521", e.target.value)}
@@ -874,6 +918,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="522"
+                            aria-label="White - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["522"] || 0}
                             onChange={(e) => updateCells("522", e.target.value)}
@@ -885,6 +930,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="523"
+                            aria-label="White - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["523"] || 0}
                             onChange={(e) => updateCells("523", e.target.value)}
@@ -896,6 +942,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="531"
+                            aria-label="White - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["531"] || 0}
                             onChange={(e) => updateCells("531", e.target.value)}
@@ -907,6 +954,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="532"
+                            aria-label="White - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["532"] || 0}
                             onChange={(e) => updateCells("532", e.target.value)}
@@ -918,6 +966,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="533"
+                            aria-label="White - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["533"] || 0}
                             onChange={(e) => updateCells("533", e.target.value)}
@@ -930,6 +979,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="541"
+                            aria-label="White - Row Total"
                             min="0"
                             value={enrollmentCount["541"] || 0}
                           />
@@ -943,6 +993,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="611"
+                            aria-label="More than one race - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["611"] || 0}
                             onChange={(e) => updateCells("611", e.target.value)}
@@ -954,6 +1005,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="612"
+                            aria-label="More than one race - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["612"] || 0}
                             onChange={(e) => updateCells("612", e.target.value)}
@@ -965,6 +1017,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="613"
+                            aria-label="More than one race - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["613"] || 0}
                             onChange={(e) => updateCells("613", e.target.value)}
@@ -976,6 +1029,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="621"
+                            aria-label="More than one race - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["621"] || 0}
                             onChange={(e) => updateCells("621", e.target.value)}
@@ -987,6 +1041,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="622"
+                            aria-label="More than one race - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["622"] || 0}
                             onChange={(e) => updateCells("622", e.target.value)}
@@ -998,6 +1053,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="623"
+                            aria-label="More than one race - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["623"] || 0}
                             onChange={(e) => updateCells("623", e.target.value)}
@@ -1009,6 +1065,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="631"
+                            aria-label="More than one race - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["631"] || 0}
                             onChange={(e) => updateCells("631", e.target.value)}
@@ -1020,6 +1077,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="632"
+                            aria-label="More than one race - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["632"] || 0}
                             onChange={(e) => updateCells("632", e.target.value)}
@@ -1031,6 +1089,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="633"
+                            aria-label="More than one race - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["633"] || 0}
                             onChange={(e) => updateCells("633", e.target.value)}
@@ -1043,6 +1102,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="641"
+                            aria-label="More than one race - Row Total"
                             min="0"
                             value={enrollmentCount["641"] || 0}
                           />
@@ -1056,6 +1116,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="711"
+                            aria-label="Unknown / Not Reported Race - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["711"] || 0}
                             onChange={(e) => updateCells("711", e.target.value)}
@@ -1067,6 +1128,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="712"
+                            aria-label="Unknown / Not Reported Race - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["712"] || 0}
                             onChange={(e) => updateCells("712", e.target.value)}
@@ -1078,6 +1140,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="713"
+                            aria-label="Unknown / Not Reported Race - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["713"] || 0}
                             onChange={(e) => updateCells("713", e.target.value)}
@@ -1089,6 +1152,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="721"
+                            aria-label="Unknown / Not Reported Race - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["721"] || 0}
                             onChange={(e) => updateCells("721", e.target.value)}
@@ -1100,6 +1164,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="722"
+                            aria-label="Unknown / Not Reported Race - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["722"] || 0}
                             onChange={(e) => updateCells("722", e.target.value)}
@@ -1111,6 +1176,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="723"
+                            aria-label="Unknown / Not Reported Race - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["723"] || 0}
                             onChange={(e) => updateCells("723", e.target.value)}
@@ -1122,6 +1188,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="731"
+                            aria-label="Unknown / Not Reported Race - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["731"] || 0}
                             onChange={(e) => updateCells("731", e.target.value)}
@@ -1133,6 +1200,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="732"
+                            aria-label="Unknown / Not Reported Race - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["732"] || 0}
                             onChange={(e) => updateCells("732", e.target.value)}
@@ -1144,6 +1212,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="733"
+                            aria-label="Unknown / Not Reported Race - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["733"] || 0}
                             onChange={(e) => updateCells("733", e.target.value)}
@@ -1156,6 +1225,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="741"
+                            aria-label="Unknown / Not Reported Race - Row Total"
                             min="0"
                             value={enrollmentCount["741"] || 0}
                           />
@@ -1170,6 +1240,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="811"
+                            aria-label="Total - Not Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["811"] || 0}
                           />
@@ -1180,6 +1251,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="812"
+                            aria-label="Total - Not Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["812"] || 0}
                           />
@@ -1190,6 +1262,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="813"
+                            aria-label="Total - Not Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["813"] || 0}
                           />
@@ -1200,6 +1273,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="821"
+                            aria-label="Total - Hispanic or Latino - Females"
                             min="0"
                             value={enrollmentCount["821"] || 0}
                           />
@@ -1210,6 +1284,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="822"
+                            aria-label="Total - Hispanic or Latino - Males"
                             min="0"
                             value={enrollmentCount["822"] || 0}
                           />
@@ -1220,6 +1295,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="823"
+                            aria-label="Total - Hispanic or Latino - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["823"] || 0}
                           />
@@ -1230,6 +1306,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="831"
+                            aria-label="Total - Unknown/Not Reported Ethnicity - Females"
                             min="0"
                             value={enrollmentCount["831"] || 0}
                           />
@@ -1240,6 +1317,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="832"
+                            aria-label="Total - Unknown/Not Reported Ethnicity - Males"
                             min="0"
                             value={enrollmentCount["832"] || 0}
                           />
@@ -1250,6 +1328,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="833"
+                            aria-label="Total - Unknown/Not Reported Ethnicity - Unknown/Not Reported Sex"
                             min="0"
                             value={enrollmentCount["833"] || 0}
                           />
@@ -1260,6 +1339,7 @@ const EnrollmentCountsForm = ({ ...props }) => {
                             type="number"
                             className="input-number"
                             name="841"
+                            aria-label="Grand Total"
                             min="0"
                             value={enrollmentCount["841"] || 0}
                           />

--- a/client/src/components/Home/Home.css
+++ b/client/src/components/Home/Home.css
@@ -128,3 +128,9 @@ img {
   width: 100%;
   height: 35%;
 }
+
+.card-body-section {
+  background-color: rgba(0, 0, 0, 0.2);
+  width: 100%;
+  padding: 0 5% 10px;
+}

--- a/client/src/components/Home/Home.js
+++ b/client/src/components/Home/Home.js
@@ -238,13 +238,15 @@ class Home extends Component {
                     alt="Header"
                     style={{ width: "60%", paddingTop: "20px" }}></img>
                 </div>
-                <h2 className="card-header" align="center" id="ToolName1">
-                  Search Cohorts
-                </h2>
-                <p className="card-text" align="center">
-                  Browse the full list of cohorts or search for cohorts based on eligibility requirements (e.g., sex,
-                  race, age) and/or types of data collected (e.g., smoking, diet, serum).
-                </p>
+                <div className="card-body-section">
+                  <h2 className="card-header" align="center" id="ToolName1">
+                    Search Cohorts
+                  </h2>
+                  <p className="card-text" align="center">
+                    Browse the full list of cohorts or search for cohorts based on eligibility requirements (e.g., sex,
+                    race, age) and/or types of data collected (e.g., smoking, diet, serum).
+                  </p>
+                </div>
               </div>
             </Link>
           </div>
@@ -262,13 +264,15 @@ class Home extends Component {
                     alt="Header"
                     style={{ width: "60%", paddingTop: "30px" }}></img>
                 </div>
-                <h2 className="card-header" align="center">
-                  Enrollment Counts
-                </h2>
-                <p className="card-text" align="center">
-                  Display enrollment counts across cohorts with the option search for specific sex, race, and ethnicity
-                  terms.
-                </p>
+                <div className="card-body-section">
+                  <h2 className="card-header" align="center">
+                    Enrollment Counts
+                  </h2>
+                  <p className="card-text" align="center">
+                    Display enrollment counts across cohorts with the option search for specific sex, race, and ethnicity
+                    terms.
+                  </p>
+                </div>
               </div>
             </Link>
           </div>
@@ -283,13 +287,15 @@ class Home extends Component {
                 <div className="card-top-coloring" style={{ backgroundColor: "#ffbf58" }}>
                   <img src="./assets/img/Cancer_Counts_Icon.png" alt="Header" style={{ width: "100%" }}></img>
                 </div>
-                <h2 className="card-header" align="center">
-                  Cancer Counts
-                </h2>
-                <p className="card-text" align="center">
-                  Display cancer counts across cohorts with the option to search for specific cancer sites and also by
-                  sex.
-                </p>
+                <div className="card-body-section">
+                  <h2 className="card-header" align="center">
+                    Cancer Counts
+                  </h2>
+                  <p className="card-text" align="center">
+                    Display cancer counts across cohorts with the option to search for specific cancer sites and also by
+                    sex.
+                  </p>
+                </div>
               </div>
             </Link>
           </div>
@@ -304,13 +310,15 @@ class Home extends Component {
                 <div className="card-top-coloring" style={{ backgroundColor: "#99b883" }}>
                   <img src="./assets/img/Biospecimen_Counts_Icon.png" alt="Header" style={{ width: "100%" }}></img>
                 </div>
-                <h2 className="card-header" align="center">
-                  Biospecimen Counts
-                </h2>
-                <p className="card-text" align="center">
-                  Search biospecimens across cohorts with the option to specify the type of biospecimen and find
-                  specimens in participants diagnosed with specific cancer sites.
-                </p>
+                <div className="card-body-section">
+                  <h2 className="card-header" align="center">
+                    Biospecimen Counts
+                  </h2>
+                  <p className="card-text" align="center">
+                    Search biospecimens across cohorts with the option to specify the type of biospecimen and find
+                    specimens in participants diagnosed with specific cancer sites.
+                  </p>
+                </div>
               </div>
             </Link>
           </div>

--- a/client/src/components/MajorContentForm/MajorContentForm.js
+++ b/client/src/components/MajorContentForm/MajorContentForm.js
@@ -734,7 +734,7 @@ const MajorContentForm = ({ ...props }) => {
               </Form.Label>
               <Col sm="12" className="mb-1">
                 <span>If data were collected at baseline, please specify all tobacco products that apply</span>
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 {errors.tobaccoUseBaseLine &&
                   errors.cigarBaseLine &&
                   errors.pipeBaseLine &&
@@ -788,7 +788,7 @@ const MajorContentForm = ({ ...props }) => {
               </Col>
               <Col sm="12" className="mb-1">
                 <span>If data were collected during follow-up, please specify all tobacco products that apply</span>
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 {errors.tobaccoUseFollowUp &&
                   errors.cigarFollowUp &&
                   errors.pipeFollowUp &&
@@ -859,7 +859,7 @@ const MajorContentForm = ({ ...props }) => {
       <Form.Group className="mb-0" style={{ marginTop: "10px" }}>
         <Form.Label style={{ marginBottom: "8px" }}>
           C.33 Do you have information on the following cancer related conditions?
-          <span style={{ color: "red" }}>*</span> <span className="font-weight-normal"> (Select all that apply)</span>
+          <span className="error-text">*</span> <span className="font-weight-normal"> (Select all that apply)</span>
           {errors.cancerRelatedConditionsNA &&
             errors.cancerToxicity &&
             errors.cancerLateEffects &&

--- a/client/src/components/MortalityForm/MortalityForm.js
+++ b/client/src/components/MortalityForm/MortalityForm.js
@@ -388,7 +388,7 @@ const MortalityForm = ({ ...props }) => {
                     name="mortalityYear"
                     type="number"
                     min="1900"
-                    style={saved && errors.mortalityYear ? { border: "1px solid red" } : {}}
+                    style={saved && errors.mortalityYear ? { border: "1px solid #b91c1c" } : {}}
                     value={mortality.mortalityYear}
                     readOnly={isReadOnly}
                     onChange={(e) => {

--- a/client/src/components/MortalityForm/MortalityForm.js
+++ b/client/src/components/MortalityForm/MortalityForm.js
@@ -497,6 +497,8 @@ const MortalityForm = ({ ...props }) => {
                 )}
               </Form.Label>
               <Col sm="6" className="align-self-center">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Do you have date of death for most subjects?</legend>
                 <Form.Check type="radio" id="haveDeathDate-no" name="haveDeathDate" inline>
                   <Form.Check.Input
                     type="radio"
@@ -526,6 +528,7 @@ const MortalityForm = ({ ...props }) => {
                   />
                   <Form.Check.Label htmlFor="haveDeathDate-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                 </Form.Check>
+                </fieldset>
               </Col>
             </Form.Group>
 
@@ -537,6 +540,8 @@ const MortalityForm = ({ ...props }) => {
                 )}
               </Form.Label>
               <Col sm="6" className="align-self-center">
+                <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+                  <legend className="sr-only">Do you have cause of death for most subjects?</legend>
                 <Form.Check type="radio" id="haveDeathCause-no" name="haveDeathCause" inline>
                   <Form.Check.Input
                     type="radio"
@@ -570,6 +575,7 @@ const MortalityForm = ({ ...props }) => {
                   />
                   <Form.Check.Label htmlFor="haveDeathCause-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                 </Form.Check>
+                </fieldset>
               </Col>
             </Form>
 

--- a/client/src/components/MortalityForm/MortalityForm.js
+++ b/client/src/components/MortalityForm/MortalityForm.js
@@ -411,7 +411,7 @@ const MortalityForm = ({ ...props }) => {
               </Form.Label>
               <Col sm="12">
                 <div key="checkbox" className="mb-3">
-                  <Form.Check className="pl-0" name="deathIndex">
+                  <Form.Check className="pl-0" id="deathIndex-checkbox" name="deathIndex">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -425,12 +425,12 @@ const MortalityForm = ({ ...props }) => {
                       }}
                     />
 
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>
+                    <Form.Check.Label htmlFor="deathIndex-checkbox" style={{ fontWeight: "normal" }}>
                       U.S. National Death Index (NDI) linkage
                     </Form.Check.Label>
                   </Form.Check>
 
-                  <Form.Check className="pl-0" name="deathCertificate">
+                  <Form.Check className="pl-0" id="deathCertificate-checkbox" name="deathCertificate">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -446,10 +446,10 @@ const MortalityForm = ({ ...props }) => {
                       }}
                     />
 
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Death Certificates</Form.Check.Label>
+                    <Form.Check.Label htmlFor="deathCertificate-checkbox" style={{ fontWeight: "normal" }}>Death Certificates</Form.Check.Label>
                   </Form.Check>
 
-                  <Form.Check className="pl-0" name="otherDeath">
+                  <Form.Check className="pl-0" id="otherDeath-checkbox" name="otherDeath">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -464,7 +464,7 @@ const MortalityForm = ({ ...props }) => {
                       }}
                     />
 
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Other</Form.Check.Label>
+                    <Form.Check.Label htmlFor="otherDeath-checkbox" style={{ fontWeight: "normal" }}>Other</Form.Check.Label>
                   </Form.Check>
                 </div>
 
@@ -497,9 +497,8 @@ const MortalityForm = ({ ...props }) => {
                 )}
               </Form.Label>
               <Col sm="6" className="align-self-center">
-                <Form.Check type="radio" name="haveDeathDate" inline>
+                <Form.Check type="radio" id="haveDeathDate-no" name="haveDeathDate" inline>
                   <Form.Check.Input
-                    type="radio"
                     type="radio"
                     className="mr-2"
                     checked={mortality.haveDeathDate === 0}
@@ -510,10 +509,10 @@ const MortalityForm = ({ ...props }) => {
                       }
                     }}
                   />
-                  <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                  <Form.Check.Label htmlFor="haveDeathDate-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                 </Form.Check>
 
-                <Form.Check type="radio" name="haveDeathDate" inline>
+                <Form.Check type="radio" id="haveDeathDate-yes" name="haveDeathDate" inline>
                   <Form.Check.Input
                     type="radio"
                     className="mr-2"
@@ -525,7 +524,7 @@ const MortalityForm = ({ ...props }) => {
                       }
                     }}
                   />
-                  <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                  <Form.Check.Label htmlFor="haveDeathDate-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                 </Form.Check>
               </Col>
             </Form.Group>
@@ -538,9 +537,8 @@ const MortalityForm = ({ ...props }) => {
                 )}
               </Form.Label>
               <Col sm="6" className="align-self-center">
-                <Form.Check type="radio" name="haveDeathCause" inline>
+                <Form.Check type="radio" id="haveDeathCause-no" name="haveDeathCause" inline>
                   <Form.Check.Input
-                    type="radio"
                     type="radio"
                     className="mr-2"
                     checked={mortality.haveDeathCause === 0}
@@ -555,12 +553,11 @@ const MortalityForm = ({ ...props }) => {
                       }
                     }}
                   />
-                  <Form.Check.Label style={{ fontWeight: "normal" }}>No</Form.Check.Label>
+                  <Form.Check.Label htmlFor="haveDeathCause-no" style={{ fontWeight: "normal" }}>No</Form.Check.Label>
                 </Form.Check>
 
-                <Form.Check type="radio" name="haveDeathCause" inline>
+                <Form.Check type="radio" id="haveDeathCause-yes" name="haveDeathCause" inline>
                   <Form.Check.Input
-                    type="radio"
                     type="radio"
                     className="mr-2"
                     checked={mortality.haveDeathCause === 1}
@@ -571,7 +568,7 @@ const MortalityForm = ({ ...props }) => {
                       }
                     }}
                   />
-                  <Form.Check.Label style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
+                  <Form.Check.Label htmlFor="haveDeathCause-yes" style={{ fontWeight: "normal" }}>Yes</Form.Check.Label>
                 </Form.Check>
               </Col>
             </Form>
@@ -583,7 +580,7 @@ const MortalityForm = ({ ...props }) => {
               </Form.Label>
               <Col sm="12">
                 <div key="checkbox" className="mb-3">
-                  <Form.Check className="pl-0" name="icd9">
+                  <Form.Check className="pl-0" id="icd9-checkbox" name="icd9">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -597,10 +594,10 @@ const MortalityForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>ICD-9</Form.Check.Label>
+                    <Form.Check.Label htmlFor="icd9-checkbox" style={{ fontWeight: "normal" }}>ICD-9</Form.Check.Label>
                   </Form.Check>
 
-                  <Form.Check className="pl-0" name="icd10">
+                  <Form.Check className="pl-0" id="icd10-checkbox" name="icd10">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -614,10 +611,10 @@ const MortalityForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>ICD-10</Form.Check.Label>
+                    <Form.Check.Label htmlFor="icd10-checkbox" style={{ fontWeight: "normal" }}>ICD-10</Form.Check.Label>
                   </Form.Check>
 
-                  <Form.Check className="pl-0" name="notCoded">
+                  <Form.Check className="pl-0" id="notCoded-checkbox" name="notCoded">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -631,10 +628,10 @@ const MortalityForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Not Coded</Form.Check.Label>
+                    <Form.Check.Label htmlFor="notCoded-checkbox" style={{ fontWeight: "normal" }}>Not Coded</Form.Check.Label>
                   </Form.Check>
 
-                  <Form.Check className="pl-0" name="otherCode">
+                  <Form.Check className="pl-0" id="otherCode-checkbox" name="otherCode">
                     <Form.Check.Input
                       bsPrefix
                       type="checkbox"
@@ -649,7 +646,7 @@ const MortalityForm = ({ ...props }) => {
                         }
                       }}
                     />
-                    <Form.Check.Label style={{ fontWeight: "normal" }}>Other Code</Form.Check.Label>
+                    <Form.Check.Label htmlFor="otherCode-checkbox" style={{ fontWeight: "normal" }}>Other Code</Form.Check.Label>
                   </Form.Check>
                 </div>
                 <Reminder

--- a/client/src/components/MortalityForm/MortalityForm.js
+++ b/client/src/components/MortalityForm/MortalityForm.js
@@ -379,7 +379,7 @@ const MortalityForm = ({ ...props }) => {
           <CollapsiblePanel condition={activePanels.A} onClick={(_) => toggleActivePanel("A")} panelTitle="Mortality">
             <Form.Group as={Row} className={saved && errors.mortalityYear && `has-error`}>
               <Form.Label column sm="12">
-                E.1 Most recent year of mortality follow up<span style={{ color: "red" }}>*</span>
+                E.1 Most recent year of mortality follow up<span className="error-text">*</span>
               </Form.Label>
               <Col sm="2">
                 <Reminder message={errors.mortalityYear} disabled={!(saved && errors.mortalityYear)} placement="right">
@@ -403,7 +403,7 @@ const MortalityForm = ({ ...props }) => {
 
             <Form.Group as={Row} className={saved && errors.otherDeathSpecify && "has-error"}>
               <Form.Label column sm="12">
-                E.2 How did your cohort confirm death?<span style={{ color: "red" }}>*</span>
+                E.2 How did your cohort confirm death?<span className="error-text">*</span>
                 <span style={{ fontWeight: "normal" }}> (Select all that apply)</span>
                 {saved && errors.deathConfirm && (
                   <span className="font-weight-normal text-danger ml-3">Required Field</span>
@@ -491,7 +491,7 @@ const MortalityForm = ({ ...props }) => {
 
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                E.3 Do you have date of death for most subjects<span style={{ color: "red" }}>*</span>
+                E.3 Do you have date of death for most subjects<span className="error-text">*</span>
                 {saved && errors.haveDeathDate && (
                   <span className="font-weight-normal text-danger ml-3">Required Field</span>
                 )}
@@ -531,7 +531,7 @@ const MortalityForm = ({ ...props }) => {
 
             <Form as={Row}>
               <Form.Label column sm="12">
-                E.4 Do you have cause of death for most subjects<span style={{ color: "red" }}>*</span>
+                E.4 Do you have cause of death for most subjects<span className="error-text">*</span>
                 {saved && errors.haveDeathCause && (
                   <span className="font-weight-normal text-danger ml-3">Required Field</span>
                 )}
@@ -673,7 +673,7 @@ const MortalityForm = ({ ...props }) => {
             <Form.Group as={Row} className={saved && errors.deathNumbers && "has-error"}>
               <Form.Label column sm="12">
                 E.5 What is the number of deaths in your cohort as of most recent mortality follow-up?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
               </Form.Label>
 
               <Col sm="2">

--- a/client/src/components/MortalityForm/MortalityForm.js
+++ b/client/src/components/MortalityForm/MortalityForm.js
@@ -688,6 +688,7 @@ const MortalityForm = ({ ...props }) => {
                     type="number"
                     min="0"
                     name="deathNumbers"
+                    aria-label="Number of deaths in cohort as of most recent mortality follow-up"
                     value={mortality.deathNumbers}
                     readOnly={isReadOnly}
                     onChange={(e) => {

--- a/client/src/components/SelectCohort/SelectCohort.js
+++ b/client/src/components/SelectCohort/SelectCohort.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
 import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
-import AccessibleSelect from "../controls/AccessibleSelect";
+import Select from "../controls/Select";
 import { useHistory } from "react-router-dom";
 import allactions from "../../actions";
 
@@ -30,7 +30,7 @@ export default function SelectCohort() {
 
       <div className="col-md-12">
         <label htmlFor="select-cohort">Select Cohort</label>
-        <AccessibleSelect
+        <Select
           inputId="select-cohort"
           options={user.cohorts.map(({ acronym, name, id }) => ({ label: `${acronym} - ${name}`, value: id }))}
           onChange={(e) => history.push(`/cohort/questionnaire/${e.value}`)}

--- a/client/src/components/SelectCohort/SelectCohort.js
+++ b/client/src/components/SelectCohort/SelectCohort.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
 import RequireAuthorization from "../RequireAuthorization/RequireAuthorization";
-import Select from "react-select";
+import AccessibleSelect from "../controls/AccessibleSelect";
 import { useHistory } from "react-router-dom";
 import allactions from "../../actions";
 
@@ -29,7 +29,9 @@ export default function SelectCohort() {
       </p>
 
       <div className="col-md-12">
-        <Select
+        <label htmlFor="select-cohort">Select Cohort</label>
+        <AccessibleSelect
+          inputId="select-cohort"
           options={user.cohorts.map(({ acronym, name, id }) => ({ label: `${acronym} - ${name}`, value: id }))}
           onChange={(e) => history.push(`/cohort/questionnaire/${e.value}`)}
         />

--- a/client/src/components/SpecimenForm/SpecimenForm.js
+++ b/client/src/components/SpecimenForm/SpecimenForm.js
@@ -837,7 +837,7 @@ const SpecimenForm = ({ ...props }) => {
             }
           }}
         />
-        <Form.Check.Label style={{ fontWeight: "normal" }}>{label}</Form.Check.Label>
+        <Form.Check.Label htmlFor={key} style={{ fontWeight: "normal" }}>{label}</Form.Check.Label>
       </Form.Check>
     );
   }

--- a/client/src/components/SpecimenForm/SpecimenForm.js
+++ b/client/src/components/SpecimenForm/SpecimenForm.js
@@ -880,7 +880,7 @@ const SpecimenForm = ({ ...props }) => {
         <Form.Group as={Row}>
           <Form.Label column sm="12">
             {field.title}
-            <span style={{ color: "red" }}>*</span>
+            <span className="error-text">*</span>
             {errors[item[0].field_id] && saved && !g1to6Flag && (
               <span className="ml-3 text-danger font-weight-normal">Required Field</span>
             )}
@@ -913,7 +913,7 @@ const SpecimenForm = ({ ...props }) => {
 
               <Col className="mb-0 pl-0" sm="12">
                 <Col sm="5">
-                  Collected at baseline<span style={{ color: "red" }}>*</span>
+                  Collected at baseline<span className="error-text">*</span>
                 </Col>
                 <Col sm="3" className="align-self-center">
                   <RadioButtonInput {...item[0]} />
@@ -963,7 +963,7 @@ const SpecimenForm = ({ ...props }) => {
 
               <Col sm="12" className="mb-0 pl-0">
                 <Col sm="5">
-                  Collected at other time points<span style={{ color: "red" }}>*</span>
+                  Collected at other time points<span className="error-text">*</span>
                 </Col>
                 <Col sm="3" className="align-self-center">
                   <RadioButtonInput {...item[1]} />
@@ -1154,7 +1154,7 @@ const SpecimenForm = ({ ...props }) => {
                 </Col>
                 <Col sm="12">
                   <div sm="12">
-                    If collected, types of aliquots (select all that apply)<span style={{ color: "red" }}>*</span>
+                    If collected, types of aliquots (select all that apply)<span className="error-text">*</span>
                     {+specimen.bioBloodBaseline === 1 &&
                       specimen.bioBloodBaselineSerum === 0 &&
                       specimen.bioBloodBaselinePlasma === 0 &&
@@ -1193,7 +1193,7 @@ const SpecimenForm = ({ ...props }) => {
                 </Col>
                 <Col sm="12">
                   <div sm="12">
-                    If collected, types of aliquots (select all that apply)<span style={{ color: "red" }}>*</span>
+                    If collected, types of aliquots (select all that apply)<span className="error-text">*</span>
                     {+specimen.bioBloodOtherTime === 1 &&
                       specimen.bioBloodOtherTimeSerum === 0 &&
                       specimen.bioBloodOtherTimePlasma === 0 &&
@@ -1238,7 +1238,7 @@ const SpecimenForm = ({ ...props }) => {
             panelTitle="Metabolomics Data">
             <Form.Group as={Row} sm="12">
               <Form.Label column sm="8">
-                G.15 Metabolomic Data (from MS and/or NMR)<span style={{ color: "red" }}>*</span>
+                G.15 Metabolomic Data (from MS and/or NMR)<span className="error-text">*</span>
                 {errors.bioMetabolomicData && saved && !g1to6Flag && (
                   <span className="ml-3 text-danger font-weight-normal">Required Field</span>
                 )}
@@ -1255,7 +1255,7 @@ const SpecimenForm = ({ ...props }) => {
             {/* G15 a */}
             <Form.Group as={Row} sm="12">
               <Form.Label column sm="12">
-                G.15a Are the biospecimens collected fasting samples?<span style={{ color: "red" }}>*</span>
+                G.15a Are the biospecimens collected fasting samples?<span className="error-text">*</span>
                 {+specimen.bioMetabolomicData === 1 && errors.bioMetaFastingSample && saved && !g1to6Flag && (
                   <span className="text-danger ml-3 font-weight-normal">Required Field</span>
                 )}
@@ -1268,7 +1268,7 @@ const SpecimenForm = ({ ...props }) => {
             {/* G15 b */}
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                G.15b What are the disease outcome(s) in your study?<span style={{ color: "red" }}>*</span>
+                G.15b What are the disease outcome(s) in your study?<span className="error-text">*</span>
                 <span className="font-weight-normal"> (Select all that apply)</span>
                 {+specimen.bioMetabolomicData === 1 &&
                   errors.bioMetaOutcomesInCancerStudy &&
@@ -1352,7 +1352,7 @@ const SpecimenForm = ({ ...props }) => {
             <Form.Group as={Row}>
               <Form.Label column sm="12">
                 G.15c Are you a member of the Consortium of Metabolomics Studies (COMETS)?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
                 {+specimen.bioMetabolomicData === 1 && errors.bioMemberOfMetabolomicsStudies && saved && (
                   <span className="text-danger ml-3 font-weight-normal">Required Field</span>
                 )}
@@ -1366,7 +1366,7 @@ const SpecimenForm = ({ ...props }) => {
             <Form.Group as={Row}>
               <Form.Label column sm="12">
                 G.15d What is the number of participants with metabolomics data in your study?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
               </Form.Label>
               <Col sm="2">
                 <Reminder
@@ -1402,7 +1402,7 @@ const SpecimenForm = ({ ...props }) => {
             {/* G15 e */}
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                G.15e Which laboratory or company was used for the analysis?<span style={{ color: "red" }}>*</span>
+                G.15e Which laboratory or company was used for the analysis?<span className="error-text">*</span>
               </Form.Label>
               <Col sm="12">
                 <Reminder
@@ -1442,7 +1442,7 @@ const SpecimenForm = ({ ...props }) => {
             <Form.Group as={Row}>
               <Form.Label column sm="12">
                 G.15f Which type(s) of analytical platform was used, (e.g., NMR, Orbitrap mass spectrometry, QTOF mass
-                spectrometry)?<span style={{ color: "red" }}>*</span>
+                spectrometry)?<span className="error-text">*</span>
               </Form.Label>
               <Col sm="12">
                 <Reminder
@@ -1483,7 +1483,7 @@ const SpecimenForm = ({ ...props }) => {
             <Form.Group as={Row}>
               <Form.Label column sm="12">
                 G.15g Which separation platform(s) was used (e.g., GC, HILIC, RPLC, Ion pairing LC)?
-                <span style={{ color: "red" }}>*</span>
+                <span className="error-text">*</span>
               </Form.Label>
               <Col sm="12">
                 <Reminder
@@ -1523,7 +1523,7 @@ const SpecimenForm = ({ ...props }) => {
 
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                G.15h How many metabolites were measured?<span style={{ color: "red" }}>*</span>
+                G.15h How many metabolites were measured?<span className="error-text">*</span>
               </Form.Label>
               <Col sm="2">
                 <Reminder
@@ -1561,7 +1561,7 @@ const SpecimenForm = ({ ...props }) => {
             {/* G15 i */}
             <Form.Group as={Row}>
               <Form.Label column sm="12">
-                G.15i What year were samples analyzed?<span style={{ color: "red" }}>*</span>
+                G.15i What year were samples analyzed?<span className="error-text">*</span>
               </Form.Label>
               <Col sm="2">
                 <Reminder

--- a/client/src/components/SpecimenForm/SpecimenForm.js
+++ b/client/src/components/SpecimenForm/SpecimenForm.js
@@ -1608,29 +1608,25 @@ const SpecimenForm = ({ ...props }) => {
               </div>
             </div>
             <div className="table-responsive m-0">
-              <Table bordered condensed className="table-valign-middle">
+              <Table bordered condensed className="table-valign-middle" aria-label="Biospecimen counts by cancer site and specimen type">
                 <thead>
                   <tr>
-                    <th className="col-sm-1 text-center">ICD-9</th>
-                    <th className="col-sm-1 text-center">ICD-10</th>
-                    <th className="col-sm-3 text-center">Cancer Site/Type</th>
-                    <th className="col-sm-1 text-center">Serum and/or Plasma</th>
-                    <th className="col-sm-1 text-center">Buffy Coat and/or Lymphocytes</th>
-                    <th className="col-sm-1 text-center">Saliva and/or Buccal</th>
-                    <th className="col-sm-1 text-center">Urine</th>
-                    <th className="col-sm-1 text-center">Feces</th>
-                    <th className="col-sm-1 text-center">Tumor Tissue Fresh/Frozen</th>
-                    <th className="col-sm-1 text-center">Tumor Tissue FFPE</th>
+                    <th scope="col" className="col-sm-1 text-center">ICD-9</th>
+                    <th scope="col" className="col-sm-1 text-center">ICD-10</th>
+                    <th scope="col" className="col-sm-3 text-center">Cancer Site/Type</th>
+                    <th scope="col" className="col-sm-1 text-center">Serum and/or Plasma</th>
+                    <th scope="col" className="col-sm-1 text-center">Buffy Coat and/or Lymphocytes</th>
+                    <th scope="col" className="col-sm-1 text-center">Saliva and/or Buccal</th>
+                    <th scope="col" className="col-sm-1 text-center">Urine</th>
+                    <th scope="col" className="col-sm-1 text-center">Feces</th>
+                    <th scope="col" className="col-sm-1 text-center">Tumor Tissue Fresh/Frozen</th>
+                    <th scope="col" className="col-sm-1 text-center">Tumor Tissue FFPE</th>
                   </tr>
                 </thead>
                 <tbody>
                   {lookup.cancer.map((c) => {
                     const keyPrefix = `${cohortId}_${c.id}`;
-                    const inputKeys = lookup.specimen
-                      .filter((k) => {
-                        return k.id < 10;
-                      })
-                      .map((k) => `${c.id}-${k.id}`);
+                    const specimenTypes = lookup.specimen.filter((k) => k.id < 10);
 
                     return (
                       <tr key={keyPrefix}>
@@ -1638,23 +1634,27 @@ const SpecimenForm = ({ ...props }) => {
                         <td className={classNames("text-nowrap", c.icd10 ? "bg-light-grey" : "bg-grey")}>{c.icd10}</td>
                         <td className="text-nowrap bg-light-grey">{c.cancer}</td>
 
-                        {inputKeys.map((key, i) => (
-                          <td key={key} className="p-0">
-                            <Form.Control
-                              className="input-number"
-                              name={key}
-                              value={specimen.counts[key] || 0}
-                              type="number"
-                              onChange={(e) => {
-                                dispatch(allactions.specimenActions.setSpecimenCount(key, e.target.value));
-                                dispatch(setHasUnsavedChanges(true));
-                              }}
-                              min="0"
-                              disabled={+g1to6Flag === 1}
-                              readOnly={isReadOnly}
-                            />
-                          </td>
-                        ))}
+                        {specimenTypes.map((k) => {
+                          const key = `${c.id}-${k.id}`;
+                          return (
+                            <td key={key} className="p-0">
+                              <Form.Control
+                                className="input-number"
+                                name={key}
+                                aria-label={`${c.cancer} - ${k.specimen}`}
+                                value={specimen.counts[key] || 0}
+                                type="number"
+                                onChange={(e) => {
+                                  dispatch(allactions.specimenActions.setSpecimenCount(key, e.target.value));
+                                  dispatch(setHasUnsavedChanges(true));
+                                }}
+                                min="0"
+                                disabled={+g1to6Flag === 1}
+                                readOnly={isReadOnly}
+                              />
+                            </td>
+                          );
+                        })}
                       </tr>
                     );
                   })}

--- a/client/src/components/controls/AccessiblePageSizeSelect.js
+++ b/client/src/components/controls/AccessiblePageSizeSelect.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-const AccessiblePageSizeSelect = ({ id = 'page-size-select', value, onChange, options }) => {
+const AccessiblePageSizeSelect = ({ id, value, onChange, options }) => {
   return (
     <span>
       <label htmlFor={id}>Page Size</label>{' '}

--- a/client/src/components/controls/AccessiblePageSizeSelect.js
+++ b/client/src/components/controls/AccessiblePageSizeSelect.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const AccessiblePageSizeSelect = ({ id, value, onChange, options }) => {
   return (
@@ -11,6 +12,13 @@ const AccessiblePageSizeSelect = ({ id, value, onChange, options }) => {
       </select>
     </span>
   );
+};
+
+AccessiblePageSizeSelect.propTypes = {
+  id: PropTypes.string.isRequired,
+  value: PropTypes.number,
+  onChange: PropTypes.func,
+  options: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.number, label: PropTypes.string })),
 };
 
 export default AccessiblePageSizeSelect;

--- a/client/src/components/controls/AccessiblePageSizeSelect.js
+++ b/client/src/components/controls/AccessiblePageSizeSelect.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 const AccessiblePageSizeSelect = ({ id = 'page-size-select', value, onChange, options }) => {
   return (

--- a/client/src/components/controls/AccessiblePageSizeSelect.js
+++ b/client/src/components/controls/AccessiblePageSizeSelect.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const AccessiblePageSizeSelect = ({ id = 'page-size-select', value, onChange, options }) => {
+  return (
+    <span>
+      <label htmlFor={id}>Page Size</label>{' '}
+      <select id={id} value={value} onChange={onChange}>
+        {options.map(opt => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    </span>
+  );
+};
+
+export default AccessiblePageSizeSelect;

--- a/client/src/components/controls/AccessiblePageSizeSelect.js
+++ b/client/src/components/controls/AccessiblePageSizeSelect.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const AccessiblePageSizeSelect = ({ id, value, onChange, options }) => {
+const AccessiblePageSizeSelect = ({ id, value, onChange, options = [] }) => {
   return (
     <span>
       <label htmlFor={id}>Page Size</label>{' '}

--- a/client/src/components/controls/AccessibleSelect.js
+++ b/client/src/components/controls/AccessibleSelect.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import Select from 'react-select';
+
+// inputId is explicitly named so callers know it must match the paired <label htmlFor>.
+// Without inputId, react-select generates a random internal id that no label can target.
+const AccessibleSelect = ({ inputId, ...props }) => {
+  return <Select inputId={inputId} {...props} />;
+};
+
+export default AccessibleSelect;

--- a/client/src/components/controls/AccessibleSelect.js
+++ b/client/src/components/controls/AccessibleSelect.js
@@ -5,7 +5,7 @@ import Select from "react-select";
 // inputId is explicitly named so callers know it must match the paired <label htmlFor>.
 // Without inputId, react-select generates a random internal id that no label can target.
 const AccessibleSelect = ({ inputId, ...props }) => {
-  return <Select inputId={inputId} {...props} />;
+  return <Select inputId={inputId} classNamePrefix="cedcd-select" {...props} />;
 };
 
 AccessibleSelect.propTypes = {

--- a/client/src/components/controls/AccessibleSelect.js
+++ b/client/src/components/controls/AccessibleSelect.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 
 // inputId is explicitly named so callers know it must match the paired <label htmlFor>.
 // Without inputId, react-select generates a random internal id that no label can target.
 const AccessibleSelect = ({ inputId, ...props }) => {
   return <Select inputId={inputId} {...props} />;
+};
+
+AccessibleSelect.propTypes = {
+  inputId: PropTypes.string.isRequired,
 };
 
 export default AccessibleSelect;

--- a/client/src/components/controls/AccessibleSelect.js
+++ b/client/src/components/controls/AccessibleSelect.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Select from 'react-select';
+import React from "react";
+import PropTypes from "prop-types";
+import Select from "react-select";
 
 // inputId is explicitly named so callers know it must match the paired <label htmlFor>.
 // Without inputId, react-select generates a random internal id that no label can target.

--- a/client/src/components/controls/PageSizeSelect.js
+++ b/client/src/components/controls/PageSizeSelect.js
@@ -1,24 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const AccessiblePageSizeSelect = ({ id, value, onChange, options = [] }) => {
+const PageSizeSelect = ({ id, value, onChange, options = [] }) => {
   return (
     <span>
-      <label htmlFor={id}>Page Size</label>{' '}
+      <label htmlFor={id}>Page Size</label>{" "}
       <select id={id} value={value} onChange={onChange}>
-        {options.map(opt => (
-          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
         ))}
       </select>
     </span>
   );
 };
 
-AccessiblePageSizeSelect.propTypes = {
+PageSizeSelect.propTypes = {
   id: PropTypes.string.isRequired,
   value: PropTypes.number,
   onChange: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.number, label: PropTypes.string })),
 };
 
-export default AccessiblePageSizeSelect;
+export default PageSizeSelect;

--- a/client/src/components/controls/Select.js
+++ b/client/src/components/controls/Select.js
@@ -1,15 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Select from "react-select";
+import ReactSelect from "react-select";
 
 // inputId is explicitly named so callers know it must match the paired <label htmlFor>.
 // Without inputId, react-select generates a random internal id that no label can target.
-const AccessibleSelect = ({ inputId, ...props }) => {
-  return <Select inputId={inputId} classNamePrefix="cedcd-select" {...props} />;
+const Select = ({ inputId, ...props }) => {
+  return <ReactSelect inputId={inputId} classNamePrefix="cedcd-select" {...props} />;
 };
 
-AccessibleSelect.propTypes = {
+Select.propTypes = {
   inputId: PropTypes.string.isRequired,
 };
 
-export default AccessibleSelect;
+export default Select;

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -1456,7 +1456,7 @@ tr.compare-row--hover,
 }
 
 // Override react-select default placeholder color (#808080) for WCAG AA contrast.
-// Scoped to the cedcd-select classNamePrefix set on AccessibleSelect.
+// Scoped to the cedcd-select classNamePrefix set on controls/Select (react-select wrapper).
 .cedcd-select__placeholder {
   color: #5e5e5e;
 }

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -1456,8 +1456,9 @@ tr.compare-row--hover,
 }
 
 // Override react-select default placeholder color (#808080) for WCAG AA contrast
-// Targets react-select's generated placeholder div class pattern
-[class$="-placeholder"] {
+// Scoped to react-select containers (class always ends in "-container") to avoid
+// accidentally restyling placeholders from other libraries.
+[class$="-container"] [class$="-placeholder"] {
   color: #5e5e5e !important;
 }
 

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -1455,11 +1455,10 @@ tr.compare-row--hover,
   color: #1a7a34 !important;
 }
 
-// Override react-select default placeholder color (#808080) for WCAG AA contrast
-// Scoped to react-select containers (class always ends in "-container") to avoid
-// accidentally restyling placeholders from other libraries.
-[class$="-container"] [class$="-placeholder"] {
-  color: #5e5e5e !important;
+// Override react-select default placeholder color (#808080) for WCAG AA contrast.
+// Scoped to the cedcd-select classNamePrefix set on AccessibleSelect.
+.cedcd-select__placeholder {
+  color: #5e5e5e;
 }
 
 .bg-light-grey {

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -163,7 +163,7 @@ body {
   border-top: none;
   border-left: none;
   border-right: none;
-  border-bottom: 1px solid red;
+  border-bottom: 1px solid #b91c1c;
   outline: none;
   background: transparent;
 }
@@ -1366,7 +1366,7 @@ tr.compare-row--hover,
 }
 
 .input-invalid label {
-  color: orangered;
+  color: #b91c1c;
 }
 
 .input-invalid input {
@@ -1377,7 +1377,7 @@ tr.compare-row--hover,
 // }
 
 .field-required label {
-  color: red;
+  color: #b91c1c;
 }
 
 .field-required label:after {
@@ -1388,7 +1388,7 @@ tr.compare-row--hover,
 // }
 
 .field-invalid label {
-  color: red;
+  color: #b91c1c;
 }
 
 .field-invalid label:after {
@@ -1442,8 +1442,12 @@ tr.compare-row--hover,
 
 .required-label:after {
   content: "*";
-  color: red;
+  color: #b91c1c;
   // margin-left: 0.25rem;
+}
+
+.error-text {
+  color: #b91c1c;
 }
 
 .bg-light-grey {

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -1450,6 +1450,17 @@ tr.compare-row--hover,
   color: #b91c1c;
 }
 
+// Override Bootstrap .text-success (#28a745 = 3.13:1) for WCAG AA contrast
+.text-success {
+  color: #1a7a34 !important;
+}
+
+// Override react-select default placeholder color (#808080) for WCAG AA contrast
+// Targets react-select's generated placeholder div class pattern
+[class$="-placeholder"] {
+  color: #5e5e5e !important;
+}
+
 .bg-light-grey {
   background-color: #f1f1f1;
 }

--- a/client/src/styles/typography.scss
+++ b/client/src/styles/typography.scss
@@ -185,7 +185,7 @@ li {
   vertical-align: top;
   background: rgba(100, 200, 100, 0);
 }
-ul.table-controls {
+.table-controls {
   padding: 0;
   margin: 0;
 }
@@ -773,7 +773,7 @@ fieldset[disabled] .btn-primary.active {
   right: 1rem;
 }
 .btn-secondary {
-  background-color: #73a4a4;
+  background-color: #507272;
   border-color: #fff;
   min-width: 100px;
   padding-left: 2rem;

--- a/client/src/styles/typography.scss
+++ b/client/src/styles/typography.scss
@@ -189,13 +189,6 @@ li {
   padding: 0;
   margin: 0;
 }
-.table-controls li {
-  display: inline-block;
-}
-.table-controls li.total {
-  margin: 4px;
-  padding: 0;
-}
 ul.results-nav li {
   list-style: none;
 }


### PR DESCRIPTION
This pull request focuses on improving accessibility and consistency in form components throughout the admin interface, primarily by replacing standard select components with accessible versions, enhancing label semantics, and standardizing error message styling. Additionally, a minor change was made to a GitHub Actions workflow variable.

target ticket [NCIATWP-9420](https://tracker.nci.nih.gov/browse/NCIATWP-9420): CEDCD: 508 Improvements

**Accessibility and Form Improvements**

* Replaced `react-select` with custom `AccessibleSelect` in `AddNewCohort.js` and `EditUser.js`, and updated multi-select usage for better accessibility and consistent API (`isMulti` prop and `inputId` usage). [[1]](diffhunk://#diff-eaf9b3f2cdd77c6b4f1cfc9c1c6e32f96891bb191279e0055b059ae072267a63L3-L5) [[2]](diffhunk://#diff-eaf9b3f2cdd77c6b4f1cfc9c1c6e32f96891bb191279e0055b059ae072267a63L376-R382) [[3]](diffhunk://#diff-eaf9b3f2cdd77c6b4f1cfc9c1c6e32f96891bb191279e0055b059ae072267a63L398-R401) [[4]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L3-L8) [[5]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L517-R506)
* Replaced the standard page size `<select>` in `CohortActivity.js` with the new `AccessiblePageSizeSelect` component for improved accessibility and consistency. [[1]](diffhunk://#diff-09f4fe17cbac2ede847338c9582287a23de0f590898cb6e2ead9f0cc9a73bd76L4-R5) [[2]](diffhunk://#diff-09f4fe17cbac2ede847338c9582287a23de0f590898cb6e2ead9f0cc9a73bd76L105-R117)
* Improved form labeling and error message styling across admin forms by introducing the `error-text` class and using semantic elements like `<fieldset>` and `<legend>` for grouped radio buttons. [[1]](diffhunk://#diff-eaf9b3f2cdd77c6b4f1cfc9c1c6e32f96891bb191279e0055b059ae072267a63L342-R344) [[2]](diffhunk://#diff-eaf9b3f2cdd77c6b4f1cfc9c1c6e32f96891bb191279e0055b059ae072267a63L359-R361) [[3]](diffhunk://#diff-eaf9b3f2cdd77c6b4f1cfc9c1c6e32f96891bb191279e0055b059ae072267a63L412-R413) [[4]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L335-R341) [[5]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L369-L379) [[6]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L389-R385) [[7]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L424-R414) [[8]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L447-R437) [[9]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L469-R462) [[10]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L487-R475) [[11]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L500-R492)
* Improved checkbox accessibility in `EditUser.js` by adding an explicit label with `htmlFor` and a unique `id`.

**Code Cleanup**

* Removed unused or commented-out code in admin form components for clarity and maintainability. [[1]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L335-R341) [[2]](diffhunk://#diff-4436de0d18c87a0035c1aefea53602b60521abfb2b0b07f5f7c7c19e753117c2L553-L567)

**DevOps**

* Updated the `CICD_ROLE_ARN` environment variable in the GitHub Actions workflow to use `${{ vars.AWS_ACCOUNT_ID }}` instead of `${{ secrets.AWS_ACCOUNT_ID }}` for consistency with other workflows.